### PR TITLE
ci: add GitHub Actions CI and npm audit workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-typecheck-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -1,0 +1,31 @@
+name: npm audit
+
+on:
+  schedule:
+    - cron: '37 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies without lifecycle scripts
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
+      - name: Audit production vulnerabilities
+        run: npm audit --omit=dev --audit-level=moderate
+
+      - name: Verify registry signatures
+        run: npm audit signatures --omit=dev


### PR DESCRIPTION
## Summary

Add GitHub Actions CI for `botler-agent`, adapted from the workflow patterns in `crossoverJie/pi`.

- **`.github/workflows/ci.yml`** — runs on push/PR to `main` with concurrency cancellation. Mirrors `pi`'s `ci.yml` but uses this repo's actual scripts (no build step, runs via `tsx`): `npm ci --ignore-scripts` → `npm run typecheck` → `npm test`.
- **`.github/workflows/npm-audit.yml`** — copied from `pi`: daily cron + manual dispatch, audits production deps (`--audit-level=moderate`) and verifies registry signatures.

Pinned to the same action versions as the reference (`checkout@v7.0.1`, `setup-node@v7.0.0`, Node 22). Skipped `pi`'s `apt` system-deps step (this project needs none) and the `pr-gate` workflow (requires an `APPROVED_CONTRIBUTORS` file + `CONTRIBUTING.md` not present here).

## Test plan

- [x] `npm run typecheck` passes locally
- [x] `npm test` passes (75 tests, 0 fail)
- [x] Workflow YAML committed on branch `ci/github-actions`

CI will validate typecheck + tests on this PR.