### PR TITLE
feat(wechat): receive inbound images as vision input + persist originals

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,11 +44,11 @@ WECHAT_ALLOW_FROM=
 # the bot proactively sends a reminder to refresh the 24h context_token window.
 # 0 = disabled; 1-24 = remind after N hours (default 23). Applies to the owner only.
 WECHAT_REMINDER_HOURS=23
-# WeChat image batching window in ms: a selected photo is delivered immediately while the user
-# may still be typing the caption. Image messages wait up to this long for a follow-up text from
-# the same sender so both are processed as one task. 0 = disable (dispatch images immediately).
-# Default 5000.
-WECHAT_IMAGE_BATCH_MS=5000
+# WeChat image batching window in seconds: a selected photo is delivered immediately while the
+# user may still be typing the caption. Image messages wait up to this long for a follow-up text
+# from the same sender so both are processed as one task. 0 = disable (dispatch images
+# immediately). Default 60.
+WECHAT_IMAGE_BATCH_SECONDS=60
 
 # ===== git commit/push =====
 # Whether to additionally git push after a write task commits (=1 to enable; default off — local commit only, push failure is a warning, not a blocker)

--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,11 @@ WECHAT_ALLOW_FROM=
 # the bot proactively sends a reminder to refresh the 24h context_token window.
 # 0 = disabled; 1-24 = remind after N hours (default 23). Applies to the owner only.
 WECHAT_REMINDER_HOURS=23
+# WeChat image batching window in ms: a selected photo is delivered immediately while the user
+# may still be typing the caption. Image messages wait up to this long for a follow-up text from
+# the same sender so both are processed as one task. 0 = disable (dispatch images immediately).
+# Default 5000.
+WECHAT_IMAGE_BATCH_MS=5000
 
 # ===== git commit/push =====
 # Whether to additionally git push after a write task commits (=1 to enable; default off — local commit only, push failure is a warning, not a blocker)

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"dev": "tsx src/index.ts",
 		"init": "tsx src/init.ts",
 		"typecheck": "tsc --noEmit",
-		"test": "tsx --test src/scheduler/cron.test.ts src/scheduler/store.test.ts src/monitor/stats.test.ts src/greeting.test.ts src/channels/wechat/aes-ecb.test.ts src/channels/wechat/download.test.ts",
+		"test": "tsx --test src/scheduler/cron.test.ts src/scheduler/store.test.ts src/monitor/stats.test.ts src/greeting.test.ts src/channels/wechat/aes-ecb.test.ts src/channels/wechat/download.test.ts src/channels/wechat/image-batch.test.ts",
 		"webui": "tsx src/webui/server.ts",
 		"cli": "tsx src/index.ts"
 	},

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"dev": "tsx src/index.ts",
 		"init": "tsx src/init.ts",
 		"typecheck": "tsc --noEmit",
-		"test": "tsx --test src/scheduler/cron.test.ts src/scheduler/store.test.ts src/monitor/stats.test.ts src/greeting.test.ts",
+		"test": "tsx --test src/scheduler/cron.test.ts src/scheduler/store.test.ts src/monitor/stats.test.ts src/greeting.test.ts src/channels/wechat/aes-ecb.test.ts src/channels/wechat/download.test.ts",
 		"webui": "tsx src/webui/server.ts",
 		"cli": "tsx src/index.ts"
 	},

--- a/src/channels/wechat/aes-ecb.test.ts
+++ b/src/channels/wechat/aes-ecb.test.ts
@@ -1,0 +1,51 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { decryptAesEcb, encryptAesEcb, parseInboundAesKey } from "./aes-ecb.ts";
+
+const KEY16 = Buffer.from("0123456789abcdef0123456789abcdef", "hex"); // 16 raw bytes
+const HEX_STR = KEY16.toString("hex"); // 32-char hex string
+
+test("decryptAesEcb round-trips encryptAesEcb", () => {
+	const plain = Buffer.from("hello wechat image payload", "utf8");
+	const cipher = encryptAesEcb(plain, KEY16);
+	assert.deepEqual(decryptAesEcb(cipher, KEY16), plain);
+});
+
+test("parseInboundAesKey accepts a 32-char hex key (image_item.aeskey)", () => {
+	assert.deepEqual(parseInboundAesKey(HEX_STR), KEY16);
+});
+
+test("parseInboundAesKey accepts base64 of the raw 16 bytes (media.aes_key)", () => {
+	assert.deepEqual(parseInboundAesKey(undefined, KEY16.toString("base64")), KEY16);
+});
+
+test("parseInboundAesKey accepts base64 of the 32-char hex string", () => {
+	const base64OfHex = Buffer.from(HEX_STR, "ascii").toString("base64");
+	assert.deepEqual(parseInboundAesKey(undefined, base64OfHex), KEY16);
+});
+
+test("parseInboundAesKey prefers the hex key over base64 when both are present", () => {
+	assert.deepEqual(parseInboundAesKey(HEX_STR, KEY16.toString("base64")), KEY16);
+});
+
+test("parseInboundAesKey rejects a non-hex aeskey", () => {
+	assert.throws(() => parseInboundAesKey("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"));
+});
+
+test("parseInboundAesKey rejects a short aeskey", () => {
+	assert.throws(() => parseInboundAesKey("abcd"));
+});
+
+test("parseInboundAesKey rejects a base64 key that decodes to the wrong length", () => {
+	// base64 of "hello" decodes to 5 bytes, neither 16 raw nor a 32-char hex string.
+	assert.throws(() => parseInboundAesKey(undefined, Buffer.from("hello", "ascii").toString("base64")));
+});
+
+test("parseInboundAesKey rejects a base64 key that decodes to 32 non-hex bytes", () => {
+	const nonHex32 = Buffer.from("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz", "ascii").toString("base64");
+	assert.throws(() => parseInboundAesKey(undefined, nonHex32));
+});
+
+test("parseInboundAesKey throws when no key is given", () => {
+	assert.throws(() => parseInboundAesKey());
+});

--- a/src/channels/wechat/aes-ecb.ts
+++ b/src/channels/wechat/aes-ecb.ts
@@ -21,24 +21,24 @@ export function decryptAesEcb(ciphertext: Buffer, key: Buffer): Buffer {
  * Resolve an inbound AES key to its 16 raw bytes.
  * Images carry the key as hex (`image_item.aeskey`, preferred) OR base64
  * (`image_item.media.aes_key`). Two base64 encodings are seen in the wild:
- * the raw 16 bytes, or base64(hex-string-of-16-bytes).
+ * the raw 16 bytes, or base64(hex-string-of-16-bytes). The parser tolerates
+ * either encoding in either field.
  */
 export function parseInboundAesKey(hexKey?: string, base64Key?: string): Buffer {
-	// Strict hex check first: Buffer.from(hex, "hex") silently drops invalid chars and yields a
-	// wrong-length / garbage key, so fail fast instead of letting decryption produce noise.
-	if (hexKey) {
-		if (!/^[0-9a-fA-F]{32}$/.test(hexKey)) {
-			throw new Error("image_item.aeskey is not a 32-char hex string");
-		}
-		return Buffer.from(hexKey, "hex");
-	}
-	if (!base64Key) throw new Error("image has no aes key");
-	const decoded = Buffer.from(base64Key, "base64");
+	const key = hexKey || base64Key;
+	if (!key) throw new Error("image has no aes key");
+	return keyFromString(key, hexKey ? "image_item.aeskey" : "image_item.media.aes_key");
+}
+
+/** Resolve a raw 16-byte key from a hex or base64 encoding; throws when neither fits. */
+function keyFromString(key: string, field: string): Buffer {
+	if (/^[0-9a-fA-F]{32}$/.test(key)) return Buffer.from(key, "hex");
+	const decoded = Buffer.from(key, "base64");
 	if (decoded.length === 16) return decoded;
 	if (decoded.length === 32 && /^[0-9a-fA-F]{32}$/.test(decoded.toString("ascii"))) {
 		return Buffer.from(decoded.toString("ascii"), "hex");
 	}
-	throw new Error("aes_key must decode to 16 raw bytes or a 32-char hex string");
+	throw new Error(`${field} must be a 32-char hex key or base64 (16 raw bytes / 32-char hex)`);
 }
 
 /** Ciphertext size of AES-128-ECB with PKCS7 padding (always pads, so +1 before rounding up). */

--- a/src/channels/wechat/aes-ecb.ts
+++ b/src/channels/wechat/aes-ecb.ts
@@ -1,14 +1,44 @@
-import { createCipheriv } from "node:crypto";
+import { createCipheriv, createDecipheriv } from "node:crypto";
 
 /**
- * AES-128-ECB helpers for CDN upload.
- * Only encryption is needed: we upload outbound media, we never download inbound media.
+ * AES-128-ECB helpers for CDN media.
+ * Encryption is used for outbound uploads, decryption for inbound image downloads.
  */
 
 /** Encrypt a buffer with AES-128-ECB (PKCS7 padding is the Node default). */
 export function encryptAesEcb(plaintext: Buffer, key: Buffer): Buffer {
 	const cipher = createCipheriv("aes-128-ecb", key, null);
 	return Buffer.concat([cipher.update(plaintext), cipher.final()]);
+}
+
+/** Decrypt a buffer with AES-128-ECB (PKCS7 padding is the Node default). */
+export function decryptAesEcb(ciphertext: Buffer, key: Buffer): Buffer {
+	const decipher = createDecipheriv("aes-128-ecb", key, null);
+	return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+}
+
+/**
+ * Resolve an inbound AES key to its 16 raw bytes.
+ * Images carry the key as hex (`image_item.aeskey`, preferred) OR base64
+ * (`image_item.media.aes_key`). Two base64 encodings are seen in the wild:
+ * the raw 16 bytes, or base64(hex-string-of-16-bytes).
+ */
+export function parseInboundAesKey(hexKey?: string, base64Key?: string): Buffer {
+	// Strict hex check first: Buffer.from(hex, "hex") silently drops invalid chars and yields a
+	// wrong-length / garbage key, so fail fast instead of letting decryption produce noise.
+	if (hexKey) {
+		if (!/^[0-9a-fA-F]{32}$/.test(hexKey)) {
+			throw new Error("image_item.aeskey is not a 32-char hex string");
+		}
+		return Buffer.from(hexKey, "hex");
+	}
+	if (!base64Key) throw new Error("image has no aes key");
+	const decoded = Buffer.from(base64Key, "base64");
+	if (decoded.length === 16) return decoded;
+	if (decoded.length === 32 && /^[0-9a-fA-F]{32}$/.test(decoded.toString("ascii"))) {
+		return Buffer.from(decoded.toString("ascii"), "hex");
+	}
+	throw new Error("aes_key must decode to 16 raw bytes or a 32-char hex string");
 }
 
 /** Ciphertext size of AES-128-ECB with PKCS7 padding (always pads, so +1 before rounding up). */

--- a/src/channels/wechat/download.test.ts
+++ b/src/channels/wechat/download.test.ts
@@ -1,0 +1,69 @@
+import { before, test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// download.ts imports safePath, which computes its allowlist from DATA_ROOT at module load and
+// throws when the directory is missing — so create a real temp DATA_ROOT (with one subproject)
+// and only then import the module dynamically.
+let download: typeof import("./download.ts");
+let tmpRoot: string;
+
+before(async () => {
+	// realpath the temp dir: on macOS os.tmpdir() lives under /var which symlinks to
+	// /private/var, and safePath's symlink-escape guard compares against the un-realpath'd
+	// allowlist — so DATA_ROOT must be a symlink-free real path for persistence tests.
+	tmpRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "botler-download-test-")));
+	fs.mkdirSync(path.join(tmpRoot, "cook"));
+	process.env.DATA_ROOT = tmpRoot;
+	download = await import("./download.ts");
+});
+
+test("sniffMime identifies PNG from magic bytes", () => {
+	const buf = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+	assert.equal(download.sniffMime(buf).mimeType, "image/png");
+	assert.equal(download.sniffMime(buf).ext, "png");
+});
+
+test("sniffMime identifies JPEG from magic bytes", () => {
+	const buf = Buffer.from([0xff, 0xd8, 0xff, 0xe0]);
+	assert.equal(download.sniffMime(buf).mimeType, "image/jpeg");
+	assert.equal(download.sniffMime(buf).ext, "jpg");
+});
+
+test("sniffMime identifies GIF from magic bytes", () => {
+	const buf = Buffer.from([0x47, 0x49, 0x46, 0x38, 0x39, 0x61]);
+	assert.equal(download.sniffMime(buf).mimeType, "image/gif");
+	assert.equal(download.sniffMime(buf).ext, "gif");
+});
+
+test("sniffMime identifies WebP from magic bytes", () => {
+	const buf = Buffer.concat([
+		Buffer.from("RIFF", "ascii"),
+		Buffer.from([0, 0, 0, 0]),
+		Buffer.from("WEBP", "ascii"),
+	]);
+	assert.equal(download.sniffMime(buf).mimeType, "image/webp");
+	assert.equal(download.sniffMime(buf).ext, "webp");
+});
+
+test("sniffMime defaults unknown bytes to JPEG", () => {
+	const buf = Buffer.from([0x00, 0x01, 0x02, 0x03]);
+	assert.equal(download.sniffMime(buf).mimeType, "image/jpeg");
+	assert.equal(download.sniffMime(buf).ext, "jpg");
+});
+
+test("persistInboundImage writes under DATA_ROOT/<project>/photos and returns the relative path", async () => {
+	const img = { buffer: Buffer.from("fake-jpeg-bytes", "utf8"), mimeType: "image/jpeg", ext: "jpg" };
+	const rel = await download.persistInboundImage(img, "cook");
+	assert.match(rel, /^cook\/photos\/\d{4}-\d{2}-\d{2}-[0-9a-f]{8}\.jpg$/);
+	const abs = path.join(tmpRoot, rel);
+	assert.ok(fs.existsSync(abs), "persisted file should exist");
+	assert.deepEqual(fs.readFileSync(abs), img.buffer);
+});
+
+test("persistInboundImage rejects a project outside the allowlist", async () => {
+	const img = { buffer: Buffer.from("x", "utf8"), mimeType: "image/jpeg", ext: "jpg" };
+	await assert.rejects(() => download.persistInboundImage(img, "../evil"));
+});

--- a/src/channels/wechat/download.ts
+++ b/src/channels/wechat/download.ts
@@ -1,0 +1,108 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { decryptAesEcb, parseInboundAesKey } from "./aes-ecb.ts";
+import { CDN_BASE_URL } from "./upload.ts";
+import { MessageItemType, type MessageItem } from "./types.ts";
+import { safePath } from "../../tools/paths.ts"; // security boundary for the persisted copy
+
+/**
+ * Inbound image pipeline for the WeChat channel.
+ *
+ * Outbound images are uploaded via upload.ts; this is the mirror half: an IMAGE message item
+ * carries a CDN download token (`encrypt_query_param` / `full_url`) + an AES-128 key; we fetch
+ * the ciphertext, decrypt it with AES-128-ECB, and hand the decoded bytes to the caller so it
+ * can both feed them inline to the model for vision recognition and persist the original under
+ * the target data subproject.
+ */
+
+/** Decoded inbound image, held in memory until the target subproject is known. */
+export interface InboundImage {
+	buffer: Buffer;
+	mimeType: string;
+	ext: string; // "jpg" | "png" | "gif" | "webp"
+}
+
+const CDN_DOWNLOAD_TIMEOUT_MS = 15_000;
+const CDN_DOWNLOAD_MAX_RETRIES = 2; // initial attempt + 1 retry
+
+/**
+ * GET the ciphertext with an AbortSignal timeout; retry once on network/timeout errors.
+ * Without a timeout a hung CDN connection would block the long-poll loop (monitor.ts).
+ */
+async function downloadWithRetry(url: string): Promise<Buffer> {
+	let lastErr: unknown;
+	for (let attempt = 1; attempt <= CDN_DOWNLOAD_MAX_RETRIES; attempt++) {
+		try {
+			const res = await fetch(url, { signal: AbortSignal.timeout(CDN_DOWNLOAD_TIMEOUT_MS) });
+			if (!res.ok) throw new Error(`CDN download client error ${res.status}`);
+			return Buffer.from(await res.arrayBuffer());
+		} catch (err) {
+			lastErr = err;
+			// 4xx is not transient; abort immediately (mirrors postToCdn's client-error handling).
+			if (err instanceof Error && /client error/.test(err.message)) throw err;
+			console.warn(`[wechat] CDN download attempt ${attempt}/${CDN_DOWNLOAD_MAX_RETRIES} failed: ${String(err)}`);
+		}
+	}
+	throw lastErr instanceof Error ? lastErr : new Error("CDN download failed");
+}
+
+/** Sniff the image format from magic bytes; defaults to JPEG when unrecognized. */
+export function sniffMime(buf: Buffer): { mimeType: string; ext: string } {
+	if (buf.length >= 8 && buf.subarray(0, 8).equals(Buffer.from("89504e470d0a1a0a", "hex"))) {
+		return { mimeType: "image/png", ext: "png" };
+	}
+	if (buf.length >= 3 && buf.subarray(0, 3).equals(Buffer.from("ffd8ff", "hex"))) {
+		return { mimeType: "image/jpeg", ext: "jpg" };
+	}
+	if (buf.length >= 4 && buf.subarray(0, 4).equals(Buffer.from("47494638", "hex"))) {
+		return { mimeType: "image/gif", ext: "gif" };
+	}
+	if (
+		buf.length >= 12 &&
+		buf.subarray(0, 4).toString("ascii") === "RIFF" &&
+		buf.subarray(8, 12).toString("ascii") === "WEBP"
+	) {
+		return { mimeType: "image/webp", ext: "webp" };
+	}
+	return { mimeType: "image/jpeg", ext: "jpg" };
+}
+
+/** Download + decrypt one inbound IMAGE item; throws when the item is not an image or cannot be decoded. */
+export async function downloadInboundImage(item: MessageItem): Promise<InboundImage> {
+	if (item.type !== MessageItemType.IMAGE) throw new Error("not an image item");
+	const img = item.image_item;
+	const media = img?.media;
+	if (!media?.encrypt_query_param && !media?.full_url) {
+		throw new Error("image item has no encrypt_query_param / full_url");
+	}
+	const key = parseInboundAesKey(img?.aeskey, media?.aes_key);
+	const url = media.full_url
+		? media.full_url
+		: `${CDN_BASE_URL}/download?encrypted_query_param=${encodeURIComponent(media.encrypt_query_param!)}`;
+
+	const cipher = await downloadWithRetry(url);
+	const plain = decryptAesEcb(cipher, key);
+	const { mimeType, ext } = sniffMime(plain);
+	return { buffer: plain, mimeType, ext };
+}
+
+const PHOTOS_SUBDIR = "photos";
+const ALLOWED_EXT = new Set(["jpg", "png", "gif", "webp"]);
+
+/**
+ * Persist a decoded image under DATA_ROOT/<project>/photos/<date>-<rand>.<ext>.
+ * Validated through safePath (first-level subdir allowlist) + an image-extension whitelist,
+ * so the file can never escape DATA_ROOT or be written with a non-image extension.
+ * Returns the RELATIVE path (e.g. cook/photos/2026-08-23-ab12cd.jpg) for the agent to cite.
+ */
+export async function persistInboundImage(img: InboundImage, project: string): Promise<string> {
+	const ext = ALLOWED_EXT.has(img.ext) ? img.ext : "jpg";
+	const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+	const name = `${date}-${crypto.randomBytes(4).toString("hex")}.${ext}`;
+	const rel = path.join(project, PHOTOS_SUBDIR, name);
+	const abs = safePath(rel); // throws if outside the allowlisted first-level subdir
+	await fs.mkdir(path.dirname(abs), { recursive: true });
+	await fs.writeFile(abs, img.buffer);
+	return rel;
+}

--- a/src/channels/wechat/download.ts
+++ b/src/channels/wechat/download.ts
@@ -75,7 +75,13 @@ export async function downloadInboundImage(item: MessageItem): Promise<InboundIm
 	const img = item.image_item;
 	const media = img?.media;
 	if (!media?.encrypt_query_param && !media?.full_url) {
-		throw new Error("image item has no encrypt_query_param / full_url");
+		// Include the available media/image keys so a decode failure on a real inbound message
+		// is debuggable from the monitor log (the protocol shape is not always exactly as expected).
+		const mediaKeys = Object.keys(media ?? {}).join(",") || "(none)";
+		const imgKeys = Object.keys(img ?? {}).join(",") || "(none)";
+		throw new Error(
+			`image item has no encrypt_query_param / full_url (image_item keys: ${imgKeys}; media keys: ${mediaKeys})`,
+		);
 	}
 	const key = parseInboundAesKey(img?.aeskey, media?.aes_key);
 	const url = media.full_url

--- a/src/channels/wechat/download.ts
+++ b/src/channels/wechat/download.ts
@@ -5,6 +5,7 @@ import { decryptAesEcb, parseInboundAesKey } from "./aes-ecb.ts";
 import { CDN_BASE_URL } from "./upload.ts";
 import { MessageItemType, type MessageItem } from "./types.ts";
 import { safePath } from "../../tools/paths.ts"; // security boundary for the persisted copy
+import { today } from "../../prompts/system-prompt.ts"; // local-tz date, matches the agent's __TODAY__
 
 /**
  * Inbound image pipeline for the WeChat channel.
@@ -98,8 +99,9 @@ const ALLOWED_EXT = new Set(["jpg", "png", "gif", "webp"]);
  */
 export async function persistInboundImage(img: InboundImage, project: string): Promise<string> {
 	const ext = ALLOWED_EXT.has(img.ext) ? img.ext : "jpg";
-	const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
-	const name = `${date}-${crypto.randomBytes(4).toString("hex")}.${ext}`;
+	// Local-timezone date (same as the agent's __TODAY__), so the file name matches the
+	// date the agent writes into its records even for UTC+8 users sending near midnight.
+	const name = `${today()}-${crypto.randomBytes(4).toString("hex")}.${ext}`;
 	const rel = path.join(project, PHOTOS_SUBDIR, name);
 	const abs = safePath(rel); // throws if outside the allowlisted first-level subdir
 	await fs.mkdir(path.dirname(abs), { recursive: true });

--- a/src/channels/wechat/image-batch.test.ts
+++ b/src/channels/wechat/image-batch.test.ts
@@ -1,0 +1,106 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { ImageBatchCoordinator } from "./image-batch.ts";
+
+// Structurally matches InboundImage ({ buffer, mimeType, ext }) without importing download.ts,
+// which would pull in the DATA_ROOT-dependent safePath at module load.
+function img(seed: string, ext = "jpg"): { buffer: Buffer; mimeType: string; ext: string } {
+	return { buffer: Buffer.from(`fake-image-${seed}`, "utf8"), mimeType: "image/jpeg", ext };
+}
+
+const WINDOW = 60_000; // seconds → ms used by the coordinator
+
+test("image message is buffered, not dispatched", () => {
+	const c = new ImageBatchCoordinator(WINDOW);
+	const action = c.onMessage("alice", { text: "", images: [img("a")] });
+	assert.equal(action.kind, "buffer");
+	assert.ok(c.hasPending("alice"));
+	assert.equal(c.pendingCount(), 1);
+});
+
+test("a second image extends the same batch", () => {
+	const c = new ImageBatchCoordinator(WINDOW);
+	c.onMessage("alice", { text: "", images: [img("a")] });
+	c.onMessage("alice", { text: "", images: [img("b")] });
+	assert.ok(c.hasPending("alice"));
+	assert.equal(c.pendingImageCount("alice"), 2);
+	const flushed = c.flush("alice")!;
+	assert.equal(flushed.images.length, 2);
+});
+
+test("text joins a pending image batch and dispatches as one task", () => {
+	const c = new ImageBatchCoordinator(WINDOW);
+	c.onMessage("alice", { text: "", images: [img("a")] });
+	const action = c.onMessage("alice", { text: "记一下这顿", images: [], contextToken: "tok2" });
+	assert.equal(action.kind, "dispatch");
+	const d = action.kind === "dispatch" ? action.dispatch : undefined!;
+	assert.equal(d.text, "记一下这顿");
+	assert.equal(d.images.length, 1);
+	assert.equal(d.contextToken, "tok2");
+	// Batch consumed by the join.
+	assert.ok(!c.hasPending("alice"));
+	assert.equal(c.pendingCount(), 0);
+});
+
+test("flush without caption dispatches the [图片] placeholder with the image", () => {
+	const c = new ImageBatchCoordinator(WINDOW);
+	c.onMessage("alice", { text: "", images: [img("a")], contextToken: "tok1" });
+	const d = c.flush("alice")!;
+	assert.equal(d.text, "[图片]");
+	assert.equal(d.images.length, 1);
+	assert.equal(d.contextToken, "tok1");
+	assert.ok(!c.hasPending("alice"));
+});
+
+test("standalone text dispatches immediately without buffering", () => {
+	const c = new ImageBatchCoordinator(WINDOW);
+	const action = c.onMessage("alice", { text: "查一下英语", images: [] });
+	assert.equal(action.kind, "dispatch");
+	const d = action.kind === "dispatch" ? action.dispatch : undefined!;
+	assert.equal(d.text, "查一下英语");
+	assert.equal(d.images.length, 0);
+	assert.ok(!c.hasPending("alice"));
+});
+
+test("flush of a sender with no pending batch returns undefined", () => {
+	const c = new ImageBatchCoordinator(WINDOW);
+	assert.equal(c.flush("nobody"), undefined);
+});
+
+test("window of 0 disables batching: images dispatch immediately", () => {
+	const c = new ImageBatchCoordinator(0);
+	const action = c.onMessage("alice", { text: "", images: [img("a")] });
+	assert.equal(action.kind, "dispatch");
+	const d = action.kind === "dispatch" ? action.dispatch : undefined!;
+	assert.equal(d.text, "[图片]");
+	assert.equal(d.images.length, 1);
+	assert.ok(!c.hasPending("alice"));
+});
+
+test("batches for different senders are independent", () => {
+	const c = new ImageBatchCoordinator(WINDOW);
+	c.onMessage("alice", { text: "", images: [img("a")] });
+	c.onMessage("bob", { text: "", images: [img("b")] });
+	assert.equal(c.pendingCount(), 2);
+	// Text for bob flushes only bob's batch.
+	const action = c.onMessage("bob", { text: "caption", images: [] });
+	const d = action.kind === "dispatch" ? action.dispatch : undefined!;
+	assert.equal(d.images.length, 1);
+	assert.ok(c.hasPending("alice"));
+	assert.ok(!c.hasPending("bob"));
+});
+
+test("batch id is deterministic and content-based", () => {
+	const c = new ImageBatchCoordinator(WINDOW);
+	c.onMessage("alice", { text: "", images: [img("a")] });
+	const d1 = c.flush("alice")!;
+	const c2 = new ImageBatchCoordinator(WINDOW);
+	c2.onMessage("alice", { text: "", images: [img("a")] });
+	const d2 = c2.flush("alice")!;
+	assert.equal(d1.id, d2.id);
+	assert.match(d1.id, /^alice:batch:/);
+});
+
+test("rejects a negative window", () => {
+	assert.throws(() => new ImageBatchCoordinator(-1));
+});

--- a/src/channels/wechat/image-batch.ts
+++ b/src/channels/wechat/image-batch.ts
@@ -1,0 +1,144 @@
+import crypto from "node:crypto";
+import type { InboundImage } from "./download.ts";
+
+/**
+ * Per-sender image batching state machine for the WeChat channel.
+ *
+ * WeChat delivers a selected photo immediately while the user may still be typing the caption
+ * ("选图即发,文字后到"), so image-bearing messages are held for a short window; a following text
+ * from the same sender joins the batch and is dispatched as ONE task (caption + vision);
+ * otherwise the image(s) alone are dispatched when the window expires. Multiple photos in the
+ * window also merge into one batch.
+ *
+ * This class is pure: it owns the batch state and the routing decision only. The caller (the
+ * monitor) owns the flush timer and the actual dispatch/send, so the window/merge/flush logic
+ * is unit-testable without the network or the dispatch chain.
+ */
+
+export interface PendingPiece {
+	/** Extracted user text (may be empty for a pure image message). */
+	text: string;
+	/** Decoded inbound images. */
+	images: InboundImage[];
+	/** Latest context_token of the messages in this piece; echoed in the reply. */
+	contextToken?: string;
+}
+
+/** A ready-to-run task: joined text + all buffered images. */
+export interface BatchDispatch {
+	/** Joined user texts, or the "[图片]" placeholder when the batch has no text. */
+	text: string;
+	images: InboundImage[];
+	contextToken?: string;
+	/** Deterministic dedup id derived from the content (caller may override with message_id). */
+	id: string;
+}
+
+export type BatchAction =
+	| { kind: "dispatch"; dispatch: BatchDispatch }
+	| { kind: "buffer" };
+
+interface PendingBatch {
+	images: InboundImage[];
+	texts: string[];
+	contextToken?: string;
+}
+
+export class ImageBatchCoordinator {
+	private readonly windowMs: number;
+	private readonly batches = new Map<string, PendingBatch>();
+
+	constructor(windowMs: number) {
+		if (!Number.isFinite(windowMs) || windowMs < 0) throw new Error("windowMs must be a non-negative number");
+		this.windowMs = windowMs;
+	}
+
+	/**
+	 * Feed one inbound message from a sender.
+	 *
+	 * Returns:
+	 * - `{ kind: "buffer" }` — image message held; the caller must (re)arm the flush timer for
+	 *   `windowMs` so the batch is eventually flushed if no caption arrives.
+	 * - `{ kind: "dispatch", dispatch }` — run this task now (standalone text, or a caption that
+	 *   joined a pending image batch, or an image dispatch when batching is disabled).
+	 */
+	onMessage(sender: string, piece: PendingPiece): BatchAction {
+		const { text, images, contextToken } = piece;
+
+		if (images.length > 0 && this.windowMs > 0) {
+			const existing = this.batches.get(sender);
+			if (existing) {
+				existing.images.push(...images);
+				if (text) existing.texts.push(text);
+				if (contextToken) existing.contextToken = contextToken;
+			} else {
+				this.batches.set(sender, {
+					images: [...images],
+					texts: text ? [text] : [],
+					contextToken,
+				});
+			}
+			return { kind: "buffer" };
+		}
+
+		// Text-only message (or batching disabled): if a pending image batch exists from this
+		// sender, the text is the caption — join and dispatch as one task now.
+		if (text) {
+			const existing = this.batches.get(sender);
+			if (existing) {
+				existing.texts.push(text);
+				if (contextToken) existing.contextToken = contextToken;
+				return { kind: "dispatch", dispatch: this.take(sender, existing) };
+			}
+		}
+
+		// Standalone text, or image dispatch when batching is disabled.
+		return { kind: "dispatch", dispatch: this.build(sender, { text, images, contextToken }, false) };
+	}
+
+	/** Flush a sender's pending batch (the flush timer fired with no caption). Returns undefined when none. */
+	flush(sender: string): BatchDispatch | undefined {
+		const existing = this.batches.get(sender);
+		if (!existing) return undefined;
+		return this.take(sender, existing);
+	}
+
+	/** Whether a sender currently has a buffered batch (tests / diagnostics). */
+	hasPending(sender: string): boolean {
+		return this.batches.has(sender);
+	}
+
+	/** Number of images currently buffered for a sender (0 when none; diagnostics/logging). */
+	pendingImageCount(sender: string): number {
+		return this.batches.get(sender)?.images.length ?? 0;
+	}
+
+	/** Number of senders with a buffered batch (tests / diagnostics). */
+	pendingCount(): number {
+		return this.batches.size;
+	}
+
+	private take(sender: string, batch: PendingBatch): BatchDispatch {
+		this.batches.delete(sender);
+		return this.build(
+			sender,
+			{ text: batch.texts.join("\n"), images: batch.images, contextToken: batch.contextToken },
+			true,
+		);
+	}
+
+	private build(sender: string, piece: PendingPiece, isBatch: boolean): BatchDispatch {
+		const { text, images, contextToken } = piece;
+		// Image-only message: keep a placeholder so greeting/routing/logs still function.
+		const safeText = text || "[图片]";
+		const imageSig = images.length
+			? crypto.createHash("md5").update(Buffer.concat(images.map((i) => i.buffer))).digest("hex").slice(0, 8)
+			: "";
+		// Short text signature so different captions on the same photo don't collide.
+		const textSig = safeText.slice(0, 20);
+		const id = isBatch
+			? `${sender}:batch:${imageSig}:${textSig}`
+			: `${sender}:${safeText}:${imageSig}`;
+		return { text: safeText, images, contextToken, id };
+	}
+}

--- a/src/channels/wechat/monitor.ts
+++ b/src/channels/wechat/monitor.ts
@@ -1,4 +1,3 @@
-import crypto from "node:crypto";
 import { CONFIG } from "../../config.ts";
 import { dispatch, DUPLICATE_SENTINEL } from "../../dispatcher.ts";
 import { recordContact } from "../../push/contacts.ts";
@@ -12,6 +11,7 @@ import {
 } from "./send-media.ts";
 import { downloadRemoteImageToTemp, uploadImageToWeixin } from "./upload.ts";
 import { downloadInboundImage, type InboundImage } from "./download.ts";
+import { ImageBatchCoordinator } from "./image-batch.ts";
 import { MessageItemType, MessageType, type MessageItem, type WeixinMessage } from "./types.ts";
 import { setChannelUp, setChannelDown } from "../../monitor/stats.ts";
 
@@ -24,57 +24,55 @@ const SESSION_EXPIRED_ERRCODE = -14;
 /** Image batching window from config, in ms (WECHAT_IMAGE_BATCH_SECONDS × 1000; 0 = disabled). */
 const IMAGE_BATCH_WINDOW_MS = CONFIG.wechatImageBatchSeconds * 1000;
 
-/** Buffered image-bearing message awaiting a possible caption from the same sender. */
-interface PendingImageBatch {
-	fromUserId: string;
-	images: InboundImage[];
-	texts: string[];
-	contextToken?: string;
-	timer: NodeJS.Timeout;
-}
-
 /**
- * Per-sender buffered image batches waiting for a caption.
+ * Image batching state machine (pure): owns the per-sender merge / flush decisions.
  * WeChat delivers a selected photo immediately, while the user may still be typing the text
- * ("选图即发,文字后到"). Image-bearing messages are held here for IMAGE_BATCH_WINDOW_MS; a
- * following text from the same sender joins the batch and flushes immediately, otherwise the
+ * ("选图即发,文字后到"). The coordinator buffers image-bearing messages for a short window; a
+ * following text from the same sender joins the batch and dispatches as one task, otherwise the
  * image(s) alone are dispatched when the window expires.
  */
-const pendingBatches = new Map<string, PendingImageBatch>();
+const batchCoordinator = new ImageBatchCoordinator(IMAGE_BATCH_WINDOW_MS);
 
-/** (Re)arm the flush timer for a batch; the window extends whenever a new message joins. */
-function armBatchTimer(batch: PendingImageBatch, opts: { baseUrl: string; token?: string }): void {
-	clearTimeout(batch.timer);
-	batch.timer = setTimeout(() => {
-		void flushBatch(batch.fromUserId, opts);
+/** Flush timers per sender, owned by the monitor (the coordinator stays pure). */
+const batchTimers = new Map<string, NodeJS.Timeout>();
+
+/** (Re)arm the flush timer for a sender; the window extends whenever a new image joins. */
+function armBatchTimer(sender: string, opts: { baseUrl: string; token?: string }): void {
+	const existing = batchTimers.get(sender);
+	if (existing) clearTimeout(existing);
+	const timer = setTimeout(() => {
+		batchTimers.delete(sender);
+		void flushBatch(sender, opts);
 	}, IMAGE_BATCH_WINDOW_MS);
 	// Do not let a pending flush timer keep the process alive on shutdown.
-	batch.timer.unref?.();
+	timer.unref?.();
+	batchTimers.set(sender, timer);
 }
 
-/** Flush a buffered batch: join its texts, dispatch as one task, send the reply. */
-async function flushBatch(fromUserId: string, opts: { baseUrl: string; token?: string }): Promise<void> {
-	const batch = pendingBatches.get(fromUserId);
-	if (!batch) return;
-	pendingBatches.delete(fromUserId);
-	clearTimeout(batch.timer);
-	const text = batch.texts.join("\n");
-	const imageSig = crypto
-		.createHash("md5")
-		.update(Buffer.concat(batch.images.map((i) => i.buffer)))
-		.digest("hex")
-		.slice(0, 8);
-	await dispatchAndReply({
-		text,
-		inboundImages: batch.images,
-		contextToken: batch.contextToken,
-		fromUserId: batch.fromUserId,
-		opts,
-		id: `${batch.fromUserId}:batch:${imageSig}:${text.slice(0, 20)}`,
-	});
+/** Cancel a sender's flush timer (called when a caption joins and dispatches immediately). */
+function cancelBatchTimer(sender: string): void {
+	const timer = batchTimers.get(sender);
+	if (timer) {
+		clearTimeout(timer);
+		batchTimers.delete(sender);
+	}
+}
+
+/** Flush a sender's buffered batch (timer fired with no caption): dispatch as one task, send the reply. */
+async function flushBatch(sender: string, opts: { baseUrl: string; token?: string }): Promise<void> {
+	const dispatch = batchCoordinator.flush(sender);
+	if (!dispatch) return;
 	console.log(
-		`[wechat] flushed image batch from ${batch.fromUserId}: ${batch.images.length} image(s), text=${JSON.stringify(text.slice(0, 40))}`,
+		`[wechat] flushed image batch from ${sender}: ${dispatch.images.length} image(s), text=${JSON.stringify(dispatch.text.slice(0, 40))}`,
 	);
+	await dispatchAndReply({
+		text: dispatch.text,
+		inboundImages: dispatch.images,
+		contextToken: dispatch.contextToken,
+		fromUserId: sender,
+		opts,
+		id: dispatch.id,
+	});
 }
 
 /** Extract plain text from item_list: first TEXT item, else VOICE-to-text. */
@@ -164,50 +162,27 @@ async function processOneMessage(
 	// the caption, so hold image-bearing messages briefly. A following text from the same sender
 	// joins the batch and flushes now; otherwise the image(s) alone are dispatched when the
 	// window expires. WECHAT_IMAGE_BATCH_SECONDS=0 disables batching (dispatch immediately).
-	if (inboundImages.length > 0 && IMAGE_BATCH_WINDOW_MS > 0) {
-		const existing = pendingBatches.get(fromUserId);
-		if (existing) {
-			existing.images.push(...inboundImages);
-			if (text) existing.texts.push(text);
-			if (contextToken) existing.contextToken = contextToken;
-			armBatchTimer(existing, opts);
-		} else {
-			const batch: PendingImageBatch = {
-				fromUserId,
-				images: inboundImages,
-				texts: text ? [text] : [],
-				contextToken,
-				timer: undefined as unknown as NodeJS.Timeout,
-			};
-			pendingBatches.set(fromUserId, batch);
-			armBatchTimer(batch, opts);
-		}
+	const action = batchCoordinator.onMessage(fromUserId, { text, images: inboundImages, contextToken });
+
+	if (action.kind === "buffer") {
+		armBatchTimer(fromUserId, opts);
 		console.log(
-			`[wechat] buffered ${inboundImages.length} image(s) from ${fromUserId} awaiting caption (${CONFIG.wechatImageBatchSeconds}s, batch has ${existing?.images.length ?? inboundImages.length} image(s))`,
+			`[wechat] buffered ${inboundImages.length} image(s) from ${fromUserId} awaiting caption (${CONFIG.wechatImageBatchSeconds}s, batch has ${batchCoordinator.pendingImageCount(fromUserId)} image(s))`,
 		);
 		return;
 	}
 
-	// Text-only message: if a pending image batch exists from this sender, the text is the
-	// caption — join it and flush now. Otherwise dispatch immediately as a standalone text task.
-	if (text) {
-		const existing = pendingBatches.get(fromUserId);
-		if (existing) {
-			existing.texts.push(text);
-			if (contextToken) existing.contextToken = contextToken;
-			clearTimeout(existing.timer);
-			await flushBatch(fromUserId, opts);
-			return;
-		}
-	}
-
+	// Dispatch now: standalone text, a caption that joined a pending image batch, or an image
+	// dispatch when batching is disabled. A caption join cancels the flush timer.
+	cancelBatchTimer(fromUserId);
+	const messageId = full.message_id != null || full.client_id != null ? String(full.message_id ?? full.client_id) : undefined;
 	await dispatchAndReply({
-		text,
-		inboundImages,
-		contextToken,
+		text: action.dispatch.text,
+		inboundImages: action.dispatch.images,
+		contextToken: action.dispatch.contextToken,
 		fromUserId,
 		opts,
-		id: full.message_id != null || full.client_id != null ? String(full.message_id ?? full.client_id) : undefined,
+		id: messageId ?? action.dispatch.id,
 	});
 }
 
@@ -218,13 +193,10 @@ async function dispatchAndReply(params: {
 	contextToken?: string;
 	fromUserId: string;
 	opts: { baseUrl: string; token?: string };
-	/** Dedup id; defaults to `${fromUserId}:${text}:${imageSig}` (image-only messages need the hash to stay distinct). */
-	id?: string;
+	/** Dedup id (from the coordinator, or the message's message_id/client_id when present). */
+	id: string;
 }): Promise<void> {
-	const { text, inboundImages, contextToken, fromUserId, opts } = params;
-
-	// Image-only message: keep a placeholder so greeting/routing/logs still function.
-	const safeText = text || "[图片]"; // isGreeting() will not match this.
+	const { text, inboundImages, contextToken, fromUserId, opts, id } = params;
 
 	// Protocol: replying requires echoing this message's context_token. Without it we
 	// cannot reply at all — log loudly instead of silently dropping the ack.
@@ -232,20 +204,8 @@ async function dispatchAndReply(params: {
 		console.warn(`[wechat] missing context_token, cannot reply to this message (protocol requires echoing it): from=${fromUserId}`);
 	}
 
-	// Dedup id: the fallback `${fromUserId}:${text.slice(0,20)}` is EMPTY for image-only messages,
-	// so two consecutive photos (no message_id/client_id) within 5 min would be mis-deduplicated.
-	// Fold in a short hash of the decoded bytes so each image is distinct.
-	const imageSig = inboundImages.length
-		? crypto
-				.createHash("md5")
-				.update(Buffer.concat(inboundImages.map((i) => i.buffer)))
-				.digest("hex")
-				.slice(0, 8)
-		: "";
-	const id = params.id ?? `${fromUserId}:${safeText}:${imageSig}`;
-
 	try {
-		const reply = await dispatch(safeText, {
+		const reply = await dispatch(text, {
 			id,
 			source: "wechat",
 			recipient: { source: "wechat", userId: fromUserId },

--- a/src/channels/wechat/monitor.ts
+++ b/src/channels/wechat/monitor.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import { CONFIG } from "../../config.ts";
 import { dispatch, DUPLICATE_SENTINEL } from "../../dispatcher.ts";
 import { recordContact } from "../../push/contacts.ts";
@@ -10,6 +11,7 @@ import {
 	sendMessageWeixin,
 } from "./send-media.ts";
 import { downloadRemoteImageToTemp, uploadImageToWeixin } from "./upload.ts";
+import { downloadInboundImage, type InboundImage } from "./download.ts";
 import { MessageItemType, MessageType, type MessageItem, type WeixinMessage } from "./types.ts";
 import { setChannelUp, setChannelDown } from "../../monitor/stats.ts";
 
@@ -57,10 +59,22 @@ async function processOneMessage(
 	const contextToken = full.context_token;
 	const text = bodyFromItemList(full.item_list);
 
+	// Decode inbound images (best-effort: one failure is warn-logged, the rest still go through).
+	// Each holds the decoded Buffer so the runner can both show it to the model and save it.
+	const inboundImages: InboundImage[] = [];
+	for (const item of full.item_list ?? []) {
+		if (item.type !== MessageItemType.IMAGE) continue;
+		try {
+			inboundImages.push(await downloadInboundImage(item));
+		} catch (e) {
+			console.warn(`[wechat] image decode failed: ${String(e)}`);
+		}
+	}
+
 	// First-deploy observability: log raw metadata so we can confirm what real inbound
 	// messages look like (message_type / from_user_id) before trusting any skip rule.
 	console.log(
-		`[wechat] inbound: from=${fromUserId || "(empty)"} type=${full.message_type ?? "?"} text=${JSON.stringify(text.slice(0, 40))}`,
+		`[wechat] inbound: from=${fromUserId || "(empty)"} type=${full.message_type ?? "?"} text=${JSON.stringify(text.slice(0, 40))} images=${inboundImages.length}`,
 	);
 
 	// Robust skip: no sender. Our own outbound echoes are built with from_user_id=""
@@ -86,7 +100,11 @@ async function processOneMessage(
 		recordContact("wechat", fromUserId);
 	}
 
-	if (!text) return; // v1 text-only: skip pure-media / empty messages
+	// v1 text-only skip becomes "no text AND no image".
+	if (!text && inboundImages.length === 0) return;
+
+	// Image-only message: keep a placeholder so greeting/routing/logs still function.
+	const safeText = text || "[图片]"; // isGreeting() will not match this.
 
 	// Protocol: replying requires echoing this message's context_token. Without it we
 	// cannot reply at all — log loudly instead of silently dropping the ack.
@@ -94,12 +112,23 @@ async function processOneMessage(
 		console.warn(`[wechat] missing context_token, cannot reply to this message (protocol requires echoing it): from=${fromUserId}`);
 	}
 
-	const id = String(full.message_id ?? full.client_id ?? `${fromUserId}:${text.slice(0, 20)}`);
+	// Dedup id: the original fallback `${fromUserId}:${text.slice(0,20)}` is EMPTY for image-only
+	// messages, so two consecutive photos (no message_id/client_id) within 5 min would be
+	// mis-deduplicated. Fold in a short hash of the decoded bytes so each image is distinct.
+	const imageSig = inboundImages.length
+		? crypto
+				.createHash("md5")
+				.update(Buffer.concat(inboundImages.map((i) => i.buffer)))
+				.digest("hex")
+				.slice(0, 8)
+		: "";
+	const id = String(full.message_id ?? full.client_id ?? `${fromUserId}:${safeText}:${imageSig}`);
 	try {
-		const reply = await dispatch(text, {
+		const reply = await dispatch(safeText, {
 			id,
 			source: "wechat",
 			recipient: { source: "wechat", userId: fromUserId },
+			inboundImages,
 		});
 		// Dedup hit returns a sentinel; don't echo it back to the user
 		if (reply.text === DUPLICATE_SENTINEL) return;

--- a/src/channels/wechat/monitor.ts
+++ b/src/channels/wechat/monitor.ts
@@ -21,6 +21,62 @@ const BACKOFF_DELAY_MS = 30_000;
 const RETRY_DELAY_MS = 2_000;
 const SESSION_EXPIRED_ERRCODE = -14;
 
+/** Image batching window from config (ms; 0 = disabled). */
+const IMAGE_BATCH_WINDOW_MS = CONFIG.wechatImageBatchMs;
+
+/** Buffered image-bearing message awaiting a possible caption from the same sender. */
+interface PendingImageBatch {
+	fromUserId: string;
+	images: InboundImage[];
+	texts: string[];
+	contextToken?: string;
+	timer: NodeJS.Timeout;
+}
+
+/**
+ * Per-sender buffered image batches waiting for a caption.
+ * WeChat delivers a selected photo immediately, while the user may still be typing the text
+ * ("选图即发,文字后到"). Image-bearing messages are held here for IMAGE_BATCH_WINDOW_MS; a
+ * following text from the same sender joins the batch and flushes immediately, otherwise the
+ * image(s) alone are dispatched when the window expires.
+ */
+const pendingBatches = new Map<string, PendingImageBatch>();
+
+/** (Re)arm the flush timer for a batch; the window extends whenever a new message joins. */
+function armBatchTimer(batch: PendingImageBatch, opts: { baseUrl: string; token?: string }): void {
+	clearTimeout(batch.timer);
+	batch.timer = setTimeout(() => {
+		void flushBatch(batch.fromUserId, opts);
+	}, IMAGE_BATCH_WINDOW_MS);
+	// Do not let a pending flush timer keep the process alive on shutdown.
+	batch.timer.unref?.();
+}
+
+/** Flush a buffered batch: join its texts, dispatch as one task, send the reply. */
+async function flushBatch(fromUserId: string, opts: { baseUrl: string; token?: string }): Promise<void> {
+	const batch = pendingBatches.get(fromUserId);
+	if (!batch) return;
+	pendingBatches.delete(fromUserId);
+	clearTimeout(batch.timer);
+	const text = batch.texts.join("\n");
+	const imageSig = crypto
+		.createHash("md5")
+		.update(Buffer.concat(batch.images.map((i) => i.buffer)))
+		.digest("hex")
+		.slice(0, 8);
+	await dispatchAndReply({
+		text,
+		inboundImages: batch.images,
+		contextToken: batch.contextToken,
+		fromUserId: batch.fromUserId,
+		opts,
+		id: `${batch.fromUserId}:batch:${imageSig}:${text.slice(0, 20)}`,
+	});
+	console.log(
+		`[wechat] flushed image batch from ${batch.fromUserId}: ${batch.images.length} image(s), text=${JSON.stringify(text.slice(0, 40))}`,
+	);
+}
+
 /** Extract plain text from item_list: first TEXT item, else VOICE-to-text. */
 function bodyFromItemList(itemList?: MessageItem[]): string {
 	if (!itemList?.length) return "";
@@ -104,6 +160,69 @@ async function processOneMessage(
 	// v1 text-only skip becomes "no text AND no image".
 	if (!text && inboundImages.length === 0) return;
 
+	// Batch window: a selected photo is delivered immediately while the user may still be typing
+	// the caption, so hold image-bearing messages briefly. A following text from the same sender
+	// joins the batch and flushes now; otherwise the image(s) alone are dispatched when the
+	// window expires. WECHAT_IMAGE_BATCH_MS=0 disables batching (dispatch immediately).
+	if (inboundImages.length > 0 && IMAGE_BATCH_WINDOW_MS > 0) {
+		const existing = pendingBatches.get(fromUserId);
+		if (existing) {
+			existing.images.push(...inboundImages);
+			if (text) existing.texts.push(text);
+			if (contextToken) existing.contextToken = contextToken;
+			armBatchTimer(existing, opts);
+		} else {
+			const batch: PendingImageBatch = {
+				fromUserId,
+				images: inboundImages,
+				texts: text ? [text] : [],
+				contextToken,
+				timer: undefined as unknown as NodeJS.Timeout,
+			};
+			pendingBatches.set(fromUserId, batch);
+			armBatchTimer(batch, opts);
+		}
+		console.log(
+			`[wechat] buffered ${inboundImages.length} image(s) from ${fromUserId} awaiting caption (${IMAGE_BATCH_WINDOW_MS}ms, batch has ${existing?.images.length ?? inboundImages.length} image(s))`,
+		);
+		return;
+	}
+
+	// Text-only message: if a pending image batch exists from this sender, the text is the
+	// caption — join it and flush now. Otherwise dispatch immediately as a standalone text task.
+	if (text) {
+		const existing = pendingBatches.get(fromUserId);
+		if (existing) {
+			existing.texts.push(text);
+			if (contextToken) existing.contextToken = contextToken;
+			clearTimeout(existing.timer);
+			await flushBatch(fromUserId, opts);
+			return;
+		}
+	}
+
+	await dispatchAndReply({
+		text,
+		inboundImages,
+		contextToken,
+		fromUserId,
+		opts,
+		id: full.message_id != null || full.client_id != null ? String(full.message_id ?? full.client_id) : undefined,
+	});
+}
+
+/** Dispatch a single task and send the reply back to the sender (text + any outbound images). */
+async function dispatchAndReply(params: {
+	text: string;
+	inboundImages: InboundImage[];
+	contextToken?: string;
+	fromUserId: string;
+	opts: { baseUrl: string; token?: string };
+	/** Dedup id; defaults to `${fromUserId}:${text}:${imageSig}` (image-only messages need the hash to stay distinct). */
+	id?: string;
+}): Promise<void> {
+	const { text, inboundImages, contextToken, fromUserId, opts } = params;
+
 	// Image-only message: keep a placeholder so greeting/routing/logs still function.
 	const safeText = text || "[图片]"; // isGreeting() will not match this.
 
@@ -113,9 +232,9 @@ async function processOneMessage(
 		console.warn(`[wechat] missing context_token, cannot reply to this message (protocol requires echoing it): from=${fromUserId}`);
 	}
 
-	// Dedup id: the original fallback `${fromUserId}:${text.slice(0,20)}` is EMPTY for image-only
-	// messages, so two consecutive photos (no message_id/client_id) within 5 min would be
-	// mis-deduplicated. Fold in a short hash of the decoded bytes so each image is distinct.
+	// Dedup id: the fallback `${fromUserId}:${text.slice(0,20)}` is EMPTY for image-only messages,
+	// so two consecutive photos (no message_id/client_id) within 5 min would be mis-deduplicated.
+	// Fold in a short hash of the decoded bytes so each image is distinct.
 	const imageSig = inboundImages.length
 		? crypto
 				.createHash("md5")
@@ -123,7 +242,8 @@ async function processOneMessage(
 				.digest("hex")
 				.slice(0, 8)
 		: "";
-	const id = String(full.message_id ?? full.client_id ?? `${fromUserId}:${safeText}:${imageSig}`);
+	const id = params.id ?? `${fromUserId}:${safeText}:${imageSig}`;
+
 	try {
 		const reply = await dispatch(safeText, {
 			id,

--- a/src/channels/wechat/monitor.ts
+++ b/src/channels/wechat/monitor.ts
@@ -59,22 +59,10 @@ async function processOneMessage(
 	const contextToken = full.context_token;
 	const text = bodyFromItemList(full.item_list);
 
-	// Decode inbound images (best-effort: one failure is warn-logged, the rest still go through).
-	// Each holds the decoded Buffer so the runner can both show it to the model and save it.
-	const inboundImages: InboundImage[] = [];
-	for (const item of full.item_list ?? []) {
-		if (item.type !== MessageItemType.IMAGE) continue;
-		try {
-			inboundImages.push(await downloadInboundImage(item));
-		} catch (e) {
-			console.warn(`[wechat] image decode failed: ${String(e)}`);
-		}
-	}
-
 	// First-deploy observability: log raw metadata so we can confirm what real inbound
 	// messages look like (message_type / from_user_id) before trusting any skip rule.
 	console.log(
-		`[wechat] inbound: from=${fromUserId || "(empty)"} type=${full.message_type ?? "?"} text=${JSON.stringify(text.slice(0, 40))} images=${inboundImages.length}`,
+		`[wechat] inbound: from=${fromUserId || "(empty)"} type=${full.message_type ?? "?"} text=${JSON.stringify(text.slice(0, 40))}`,
 	);
 
 	// Robust skip: no sender. Our own outbound echoes are built with from_user_id=""
@@ -98,6 +86,19 @@ async function processOneMessage(
 	if (contextToken) {
 		updateContext(fromUserId, contextToken);
 		recordContact("wechat", fromUserId);
+	}
+
+	// Decode inbound images (best-effort: one failure is warn-logged, the rest still go through).
+	// Each holds the decoded Buffer so the runner can both show it to the model and save it.
+	// Runs AFTER the allowlist check so unauthorized senders never trigger a CDN download/decrypt.
+	const inboundImages: InboundImage[] = [];
+	for (const item of full.item_list ?? []) {
+		if (item.type !== MessageItemType.IMAGE) continue;
+		try {
+			inboundImages.push(await downloadInboundImage(item));
+		} catch (e) {
+			console.warn(`[wechat] image decode failed: ${String(e)}`);
+		}
 	}
 
 	// v1 text-only skip becomes "no text AND no image".

--- a/src/channels/wechat/monitor.ts
+++ b/src/channels/wechat/monitor.ts
@@ -21,8 +21,8 @@ const BACKOFF_DELAY_MS = 30_000;
 const RETRY_DELAY_MS = 2_000;
 const SESSION_EXPIRED_ERRCODE = -14;
 
-/** Image batching window from config (ms; 0 = disabled). */
-const IMAGE_BATCH_WINDOW_MS = CONFIG.wechatImageBatchMs;
+/** Image batching window from config, in ms (WECHAT_IMAGE_BATCH_SECONDS × 1000; 0 = disabled). */
+const IMAGE_BATCH_WINDOW_MS = CONFIG.wechatImageBatchSeconds * 1000;
 
 /** Buffered image-bearing message awaiting a possible caption from the same sender. */
 interface PendingImageBatch {
@@ -163,7 +163,7 @@ async function processOneMessage(
 	// Batch window: a selected photo is delivered immediately while the user may still be typing
 	// the caption, so hold image-bearing messages briefly. A following text from the same sender
 	// joins the batch and flushes now; otherwise the image(s) alone are dispatched when the
-	// window expires. WECHAT_IMAGE_BATCH_MS=0 disables batching (dispatch immediately).
+	// window expires. WECHAT_IMAGE_BATCH_SECONDS=0 disables batching (dispatch immediately).
 	if (inboundImages.length > 0 && IMAGE_BATCH_WINDOW_MS > 0) {
 		const existing = pendingBatches.get(fromUserId);
 		if (existing) {
@@ -183,7 +183,7 @@ async function processOneMessage(
 			armBatchTimer(batch, opts);
 		}
 		console.log(
-			`[wechat] buffered ${inboundImages.length} image(s) from ${fromUserId} awaiting caption (${IMAGE_BATCH_WINDOW_MS}ms, batch has ${existing?.images.length ?? inboundImages.length} image(s))`,
+			`[wechat] buffered ${inboundImages.length} image(s) from ${fromUserId} awaiting caption (${CONFIG.wechatImageBatchSeconds}s, batch has ${existing?.images.length ?? inboundImages.length} image(s))`,
 		);
 		return;
 	}

--- a/src/channels/wechat/upload.ts
+++ b/src/channels/wechat/upload.ts
@@ -15,8 +15,11 @@ import { UploadMediaType } from "./types.ts";
  * it is referenced in an outbound IMAGE message item.
  */
 
-/** WeChat media CDN root. Not configurable: there is no known reason to point elsewhere. */
-const CDN_BASE_URL = "https://novac2c.cdn.weixin.qq.com/c2c";
+/**
+ * WeChat media CDN root, shared by the outbound upload path and the inbound download path.
+ * Not configurable: there is no known reason to point elsewhere.
+ */
+export const CDN_BASE_URL = "https://novac2c.cdn.weixin.qq.com/c2c";
 
 /** Temp dir for remote images downloaded before upload. */
 const MEDIA_TEMP_DIR = path.join(os.tmpdir(), "botler-agent", "wechat");

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,6 +57,12 @@ export interface ModelMeta {
 	reasoning: boolean;
 	contextWindow: number;
 	maxTokens: number;
+	/**
+	 * Whether the model accepts image input (vision). Defaults to true, matching pi-ai's
+	 * built-in default of text+image; set false for text-only models. When false, pi-ai
+	 * replaces image content blocks with a placeholder instead of sending them.
+	 */
+	vision?: boolean;
 }
 
 /** Wire protocol for a custom provider (default: OpenAI Chat Completions). */
@@ -169,6 +175,7 @@ function loadProvidersFile(): CustomProviderConfig[] {
 					reasoning: mm.reasoning === true,
 					contextWindow: Number(mm.contextWindow) || 0,
 					maxTokens: Number(mm.maxTokens) || 0,
+					vision: mm.vision,
 				});
 			}
 			if (models.length === 0) continue;

--- a/src/config.ts
+++ b/src/config.ts
@@ -101,6 +101,12 @@ export interface Config {
 	 * when they've been quiet this long (clamped to <=24 so the "hours remaining" copy is never negative).
 	 */
 	wechatReminderHours: number;
+	/**
+	 * WeChat image batching window in ms: a selected photo is delivered immediately, while the
+	 * user may still be typing the caption. Image-bearing messages are buffered this long for a
+	 * follow-up text from the same sender; 0 disables batching (dispatch immediately).
+	 */
+	wechatImageBatchMs: number;
 	/** When GIT_PUSH=1, additionally git push after a write task commits (failure is only a warning; default off). */
 	gitPush: boolean;
 	/** When WEBUI_ENABLED=1, start the local task-log UI (binds 127.0.0.1 only). */
@@ -224,6 +230,17 @@ function parseWechatReminderHours(): number {
 	return Number.isFinite(n) && n >= 1 ? Math.min(n, 24) : 23;
 }
 
+/**
+ * Parse WECHAT_IMAGE_BATCH_MS. "0" explicitly disables batching; a positive integer sets the
+ * window; anything invalid falls back to the default 5000ms.
+ */
+function parseWechatImageBatchMs(): number {
+	const raw = process.env.WECHAT_IMAGE_BATCH_MS;
+	if (raw === "0") return 0;
+	const n = Number(raw ?? "5000");
+	return Number.isFinite(n) && n >= 0 ? Math.floor(n) : 5000;
+}
+
 export const CONFIG: Config = {
 	dataRoot: process.env.DATA_ROOT ?? "",
 	provider: process.env.PI_PROVIDER ?? "anthropic",
@@ -238,6 +255,7 @@ export const CONFIG: Config = {
 	wechatEnabled: process.env.WECHAT_ENABLED === "1",
 	wechatAllowFrom: process.env.WECHAT_ALLOW_FROM || undefined,
 	wechatReminderHours: parseWechatReminderHours(),
+	wechatImageBatchMs: parseWechatImageBatchMs(),
 	gitPush: process.env.GIT_PUSH === "1",
 	webuiEnabled: process.env.WEBUI_ENABLED === "1",
 	webuiPort: Number(process.env.WEBUI_PORT ?? "8900"),

--- a/src/config.ts
+++ b/src/config.ts
@@ -102,11 +102,11 @@ export interface Config {
 	 */
 	wechatReminderHours: number;
 	/**
-	 * WeChat image batching window in ms: a selected photo is delivered immediately, while the
+	 * WeChat image batching window in seconds: a selected photo is delivered immediately, while the
 	 * user may still be typing the caption. Image-bearing messages are buffered this long for a
 	 * follow-up text from the same sender; 0 disables batching (dispatch immediately).
 	 */
-	wechatImageBatchMs: number;
+	wechatImageBatchSeconds: number;
 	/** When GIT_PUSH=1, additionally git push after a write task commits (failure is only a warning; default off). */
 	gitPush: boolean;
 	/** When WEBUI_ENABLED=1, start the local task-log UI (binds 127.0.0.1 only). */
@@ -231,14 +231,14 @@ function parseWechatReminderHours(): number {
 }
 
 /**
- * Parse WECHAT_IMAGE_BATCH_MS. "0" explicitly disables batching; a positive integer sets the
- * window; anything invalid falls back to the default 5000ms.
+ * Parse WECHAT_IMAGE_BATCH_SECONDS. "0" explicitly disables batching; a positive integer sets the
+ * window in seconds; anything invalid falls back to the default 60.
  */
-function parseWechatImageBatchMs(): number {
-	const raw = process.env.WECHAT_IMAGE_BATCH_MS;
+function parseWechatImageBatchSeconds(): number {
+	const raw = process.env.WECHAT_IMAGE_BATCH_SECONDS;
 	if (raw === "0") return 0;
-	const n = Number(raw ?? "5000");
-	return Number.isFinite(n) && n >= 0 ? Math.floor(n) : 5000;
+	const n = Number(raw ?? "60");
+	return Number.isFinite(n) && n >= 0 ? Math.floor(n) : 60;
 }
 
 export const CONFIG: Config = {
@@ -255,7 +255,7 @@ export const CONFIG: Config = {
 	wechatEnabled: process.env.WECHAT_ENABLED === "1",
 	wechatAllowFrom: process.env.WECHAT_ALLOW_FROM || undefined,
 	wechatReminderHours: parseWechatReminderHours(),
-	wechatImageBatchMs: parseWechatImageBatchMs(),
+	wechatImageBatchSeconds: parseWechatImageBatchSeconds(),
 	gitPush: process.env.GIT_PUSH === "1",
 	webuiEnabled: process.env.WEBUI_ENABLED === "1",
 	webuiPort: Number(process.env.WEBUI_PORT ?? "8900"),

--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -6,6 +6,7 @@ import { appendTaskLog } from "./logging/store.ts";
 import { CONFIG } from "./config.ts";
 import type { Recipient } from "./push/types.ts";
 import type { TaskLog, TaskStatus, TokenUsageLog } from "./logging/types.ts";
+import type { InboundImage } from "./channels/wechat/download.ts";
 import {
 	markEnqueued,
 	markStarted,
@@ -26,6 +27,11 @@ export interface DispatchOptions {
 	projectHint?: string;
 	/** Optional recipient: the sender of this message. Tools like schedule inject it as the push target. */
 	recipient?: Recipient;
+	/**
+	 * Inbound images (decoded bytes) to feed the model as vision input AND persist under the
+	 * target subproject. WeChat-only for now. Distinct from DispatchResult.images (outbound).
+	 */
+	inboundImages?: InboundImage[];
 }
 
 export interface DispatchResult {
@@ -148,6 +154,7 @@ export async function dispatch(message: string, opts: DispatchOptions = {}): Pro
 				phase: "execute",
 				projectHint: opts.projectHint,
 				recipient: opts.recipient,
+				inboundImages: opts.inboundImages,
 			});
 			const log = result.log;
 			if (!log) {

--- a/src/greeting.ts
+++ b/src/greeting.ts
@@ -39,10 +39,19 @@ export function greetingReply(): string {
 	);
 }
 
-/** Static fallback when a message cannot be routed to any subproject. */
-export function fallbackUnknownReply(): string {
+/**
+ * Static fallback when a message cannot be routed to any subproject.
+ * When the message carried inbound images, guide the user explicitly: image content only helps
+ * if the model can see it, so suggest adding a short text hint (and mention the model caveat).
+ */
+export function fallbackUnknownReply(hasImages = false): string {
+	const imageHint = hasImages
+		? "📷 我收到了你发的图片，但当前模型无法识别图片内容，所以我没确定要操作哪个子项目。\n" +
+			"请补充一句文字说明，比如「记一下这顿饭」，让我知道该写到哪个项目。\n\n"
+		: "";
 	return (
 		"😅 我有点没跟上——没太确定你想操作哪个数据子项目。\n\n" +
+		imageHint +
 		"我是你的个人数据助手，只能在下面的子项目里读写数据、运行项目内脚本。想做什么直接说就行，" +
 		"比如记账、查词、记录日常；也可以让我「创建定时任务 / 提醒」。\n\n" +
 		`当前可用的子项目：\n${projectList()}\n\n` +

--- a/src/init.ts
+++ b/src/init.ts
@@ -61,8 +61,9 @@ botler-agent 代码强制，不因本文件内容而改变。
 						baseUrl: "https://your-gateway.example.com/v1",
 						apiKey: "sk-REPLACE_ME",
 						models: [
-							{ id: "your-model-pro", name: "Your Model Pro", reasoning: true, contextWindow: 1048576, maxTokens: 393216 },
-							{ id: "your-model-flash", name: "Your Model Flash", reasoning: false, contextWindow: 1048576, maxTokens: 393216 },
+							// vision defaults to true (image input enabled); set `vision: false` for text-only models.
+							{ id: "your-model-pro", name: "Your Model Pro", reasoning: true, contextWindow: 1048576, maxTokens: 393216, vision: true },
+							{ id: "your-model-flash", name: "Your Model Flash", reasoning: false, contextWindow: 1048576, maxTokens: 393216, vision: true },
 						],
 					},
 				},

--- a/src/logging/collect.ts
+++ b/src/logging/collect.ts
@@ -60,6 +60,8 @@ export interface CollectInput {
 	userMessage: string;
 	replyText: string;
 	images: string[];
+	/** Number of inbound images that accompanied this message. */
+	inboundImageCount?: number;
 	mutated: boolean;
 	/** execute-phase agent.state.messages (empty for early-return paths). */
 	messages: AgentMessage[];
@@ -86,6 +88,7 @@ export function collectTaskLog(input: CollectInput): TaskLog {
 		replyText,
 		images,
 		mutated,
+		inboundImageCount,
 	messages,
 	routingUsage,
 	routing,
@@ -209,6 +212,7 @@ export function collectTaskLog(input: CollectInput): TaskLog {
 		systemPrompt,
 		modelCache,
 	};
+	if (inboundImageCount !== undefined) log.inboundImageCount = inboundImageCount;
 
 	if (routing) {
 		log.routing = {

--- a/src/logging/types.ts
+++ b/src/logging/types.ts
@@ -108,6 +108,8 @@ export interface TaskLog {
 	userMessage: string;
 	replyText: string;
 	images: string[];
+	/** Number of inbound images that accompanied this message (observability for image-only messages). */
+	inboundImageCount?: number;
 	mutated: boolean;
 	tools: ToolCallLog[];
 	conversation: ConversationEntry[];

--- a/src/prompts/system-prompt.ts
+++ b/src/prompts/system-prompt.ts
@@ -224,8 +224,8 @@ export function loadSystemPrompt(projectName?: string): string {
 		.replaceAll("__TODAY__", today());
 }
 
-/** Today's date in the local timezone (YYYY-MM-DD). */
-function today(): string {
+/** Today's date in the local timezone (YYYY-MM-DD). Shared with inbound image persistence so file names match the agent's notion of "today". */
+export function today(): string {
 	const d = new Date();
 	const m = String(d.getMonth() + 1).padStart(2, "0");
 	const day = String(d.getDate()).padStart(2, "0");

--- a/src/prompts/system-prompt.ts
+++ b/src/prompts/system-prompt.ts
@@ -181,17 +181,21 @@ function schedulerContext(): string {
  * The virtual `__scheduler__` project is included as a candidate for schedule-management messages,
  * unless `includeScheduler` is false (scheduler-fired reminders are never schedule-management requests).
  */
-export function buildRoutePrompt(userMessage: string, includeScheduler = true): string {
+export function buildRoutePrompt(userMessage: string, includeScheduler = true, hasImages = false): string {
 	const schedulerLine = includeScheduler
 		? `- ${SCHEDULER_VIRTUAL_PROJECT}/：仅用于创建/管理定时任务（与数据子项目无关）\n`
+		: "";
+	// Image guidance: routing hints in each project summary are keyword/text based, so tell the
+	// model explicitly that an image is attached and to judge by its content too (e.g. a food
+	// photo should land in the project whose description mentions diet/meals).
+	const imageLine = hasImages
+		? "\n本条消息附带图片。请同时参考图片内容与文字判断所属子项目：图片内容明显匹配某个子项目的描述（如食物照片 → 记录饮食的项目）时选择该项目；无法根据图片与文字确定时输出 UNKNOWN。\n"
 		: "";
 	return `你是路由助手，负责判断用户消息要操作哪个数据子项目。只输出一个项目名（不含斜杠），无法确定时只输出 UNKNOWN。不要使用任何工具。
 
 数据根目录下的子项目：
-${listProjectSummaries()}${schedulerLine}
-用户消息：${userMessage}
-
-判断这条消息属于哪个子项目。只输出项目名（如 my-project）或 UNKNOWN。`;
+${listProjectSummaries()}${schedulerLine}用户消息：${userMessage}
+${imageLine}判断这条消息属于哪个子项目。只输出项目名（如 my-project）或 UNKNOWN。`;
 }
 
 /**

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -15,7 +15,10 @@ function buildModel(providerId: string, baseUrl: string, api: CustomProviderApi,
 		provider: providerId,
 		baseUrl,
 		reasoning: m.reasoning,
-		input: ["text"],
+		// Declare image input support so pi-ai sends image blocks instead of replacing them
+		// with a "(image omitted)" placeholder. Defaults to text+image (pi-ai's built-in
+		// default); set `vision: false` in providers.json for text-only models.
+		input: m.vision === false ? ["text"] : ["text", "image"],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: m.contextWindow,
 		maxTokens: m.maxTokens,

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -204,6 +204,7 @@ async function routeProject(
 	model: AnyModel,
 	includeScheduler: boolean,
 	images?: ImageContent[],
+	hasImages = false,
 ): Promise<{ project: string | null; usage?: Usage; prompt?: string; candidates: string[] }> {
 	const projects = listProjectDirs();
 	if (projects.length === 0) return { project: null, candidates: [] };
@@ -213,7 +214,7 @@ async function routeProject(
 	// single-project shortcut above intentionally ignores it (the schedule tool stays available
 	// in any execution context, so single-project setups still work).
 	const candidates = includeScheduler ? [...projects, SCHEDULER_VIRTUAL_PROJECT] : projects;
-	const prompt = buildRoutePrompt(userMessage, includeScheduler);
+	const prompt = buildRoutePrompt(userMessage, includeScheduler, hasImages);
 	const agent = new Agent({
 		initialState: {
 			systemPrompt: prompt,
@@ -258,6 +259,7 @@ function buildMinimalLog(opts: {
 		replyText: opts.replyText,
 		images: [],
 		mutated: false,
+		inboundImageCount: opts.ctx.inboundImages?.length ?? 0,
 		messages: [],
 		routingUsage: opts.routingUsage,
 		routing: opts.routing,
@@ -319,7 +321,13 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 		routingPrompt = undefined;
 		routingCandidates = [...projects, SCHEDULER_VIRTUAL_PROJECT];
 	} else {
-		const routed = await routeProject(userMessage, model, ctx.source !== "scheduler", imagesContent);
+		const routed = await routeProject(
+			userMessage,
+			model,
+			ctx.source !== "scheduler",
+			imagesContent,
+			inboundImages.length > 0,
+		);
 		project = routed.project;
 		routingUsage = routed.usage;
 		routingPrompt = routed.prompt;

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -334,7 +334,7 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 		routingCandidates = routed.candidates;
 	}
 	if (!project) {
-		const replyText = fallbackUnknownReply();
+		const replyText = fallbackUnknownReply(inboundImages.length > 0);
 		return {
 			text: replyText,
 			images: [],

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -279,6 +279,8 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 	const ctx: RunLogContext = logCtx ?? { taskId: randomUUID(), source: "cli", phase: "execute" };
 	const startedAt = Date.now();
 	const inboundImages = ctx.inboundImages ?? [];
+	// Base64-encode each inbound image exactly once and reuse it for routing + execution.
+	const imagesContent = toImageContent(inboundImages);
 	const model = resolveModel();
 	const projects = listProjectDirs();
 	if (projects.length === 0) {
@@ -317,7 +319,7 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 		routingPrompt = undefined;
 		routingCandidates = [...projects, SCHEDULER_VIRTUAL_PROJECT];
 	} else {
-		const routed = await routeProject(userMessage, model, ctx.source !== "scheduler", toImageContent(inboundImages));
+		const routed = await routeProject(userMessage, model, ctx.source !== "scheduler", imagesContent);
 		project = routed.project;
 		routingUsage = routed.usage;
 		routingPrompt = routed.prompt;
@@ -344,15 +346,18 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 
 	// Persist originals under DATA_ROOT/<project>/photos, then tell the agent where they are.
 	// Persistence happens only after a subproject is known — unrouted / unknown-project messages
-	// (returned above) never write a photo into DATA_ROOT. The file is written by the framework
-	// (a transport concern), validated through safePath + an image-extension whitelist; the agent
-	// only ever receives the relative path as text to cite in its record.
+	// (returned above) never write a photo into DATA_ROOT, and the virtual __scheduler__ project
+	// is not a data subproject (nothing to persist, avoids a spurious warn). The file is written
+	// by the framework (a transport concern), validated through safePath + an image-extension
+	// whitelist; the agent only ever receives the relative path as text to cite in its record.
 	const savedPaths: string[] = [];
-	for (const img of inboundImages) {
-		try {
-			savedPaths.push(await persistInboundImage(img, project!));
-		} catch (e) {
-			console.warn(`[runner] persist image failed: ${String(e)}`);
+	if (inboundImages.length > 0 && project !== SCHEDULER_VIRTUAL_PROJECT) {
+		for (const img of inboundImages) {
+			try {
+				savedPaths.push(await persistInboundImage(img, project!));
+			} catch (e) {
+				console.warn(`[runner] persist image failed: ${String(e)}`);
+			}
 		}
 	}
 	const attachmentNote = savedPaths.length
@@ -405,7 +410,7 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 		markAgentStart();
 		// Inline vision (decoded bytes) + the saved-path note, so the model can both see the
 		// image and reference its persisted location in the data file.
-		await agent.prompt(execText, toImageContent(inboundImages));
+		await agent.prompt(execText, imagesContent);
 	} finally {
 		markAgentEnd();
 		setTaskContext(null);

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -3,12 +3,13 @@ import { randomUUID } from "node:crypto";
 import { Agent } from "@earendil-works/pi-agent-core";
 import { createModels } from "@earendil-works/pi-ai";
 import { anthropicProvider } from "@earendil-works/pi-ai/providers/anthropic";
-import type { AssistantMessage, Model, Usage } from "@earendil-works/pi-ai";
+import type { AssistantMessage, ImageContent, Model, Usage } from "@earendil-works/pi-ai";
 // Model is generic; here we use any to denote a model of any provider API
 type AnyModel = Model<any>;
 import { fileTools } from "./tools/index.ts";
 import { setTaskContext } from "./tools/task-context.ts";
 import { safePath } from "./tools/paths.ts";
+import { persistInboundImage, type InboundImage } from "./channels/wechat/download.ts";
 import {
 	loadSystemPrompt,
 	buildRoutePrompt,
@@ -77,6 +78,8 @@ export interface RunLogContext {
 	projectHint?: string;
 	/** Optional recipient (the message sender); injected into the task context for tools like schedule. */
 	recipient?: Recipient;
+	/** Inbound images (decoded bytes) to feed the model as vision input AND persist under the target subproject. */
+	inboundImages?: InboundImage[];
 }
 
 export interface TaskResult {
@@ -121,6 +124,15 @@ function extractImages(text: string): { text: string; images: string[] } {
 		}
 	}
 	return { text: text.replace(IMAGE_REF_RE, "").trim(), images };
+}
+
+/** InboundImage[] -> ImageContent[] for the model (base64 inline vision). */
+function toImageContent(inboundImages: InboundImage[]): ImageContent[] {
+	return inboundImages.map((i) => ({
+		type: "image",
+		data: i.buffer.toString("base64"),
+		mimeType: i.mimeType,
+	}));
 }
 
 /** Take the body of the last assistant message from state; returns empty string if none or on failure. */
@@ -191,6 +203,7 @@ async function routeProject(
 	userMessage: string,
 	model: AnyModel,
 	includeScheduler: boolean,
+	images?: ImageContent[],
 ): Promise<{ project: string | null; usage?: Usage; prompt?: string; candidates: string[] }> {
 	const projects = listProjectDirs();
 	if (projects.length === 0) return { project: null, candidates: [] };
@@ -209,7 +222,7 @@ async function routeProject(
 		},
 		streamFn: models.streamSimple.bind(models),
 	});
-	await agent.prompt(userMessage);
+	await agent.prompt(userMessage, images);
 	const decision = parseRoute(lastAssistantText(agent.state), candidates);
 	// Routing state is [user, assistant]; the assistant message carries a single clean usage.
 	const assistant = agent.state.messages[agent.state.messages.length - 1];
@@ -265,6 +278,7 @@ function buildMinimalLog(opts: {
 export async function runTask(userMessage: string, logCtx?: RunLogContext): Promise<TaskResult> {
 	const ctx: RunLogContext = logCtx ?? { taskId: randomUUID(), source: "cli", phase: "execute" };
 	const startedAt = Date.now();
+	const inboundImages = ctx.inboundImages ?? [];
 	const model = resolveModel();
 	const projects = listProjectDirs();
 	if (projects.length === 0) {
@@ -280,7 +294,8 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 	// Greeting short-circuit: a bare greeting has nothing to route to, so skip the routing
 	// LLM call entirely and reply with a friendly welcome (zero extra LLM cost). Programmatic
 	// messages that carry a projectHint, and scheduler-fired tasks, never take this path.
-	if (!ctx.projectHint && ctx.source !== "scheduler" && isGreeting(userMessage)) {
+	// A message that carries an image is NEVER a greeting — skip the check so the image is not swallowed.
+	if (!ctx.projectHint && ctx.source !== "scheduler" && inboundImages.length === 0 && isGreeting(userMessage)) {
 		const replyText = greetingReply();
 		return {
 			text: replyText,
@@ -302,7 +317,7 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 		routingPrompt = undefined;
 		routingCandidates = [...projects, SCHEDULER_VIRTUAL_PROJECT];
 	} else {
-		const routed = await routeProject(userMessage, model, ctx.source !== "scheduler");
+		const routed = await routeProject(userMessage, model, ctx.source !== "scheduler", toImageContent(inboundImages));
 		project = routed.project;
 		routingUsage = routed.usage;
 		routingPrompt = routed.prompt;
@@ -326,6 +341,24 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 			}),
 		};
 	}
+
+	// Persist originals under DATA_ROOT/<project>/photos, then tell the agent where they are.
+	// Persistence happens only after a subproject is known — unrouted / unknown-project messages
+	// (returned above) never write a photo into DATA_ROOT. The file is written by the framework
+	// (a transport concern), validated through safePath + an image-extension whitelist; the agent
+	// only ever receives the relative path as text to cite in its record.
+	const savedPaths: string[] = [];
+	for (const img of inboundImages) {
+		try {
+			savedPaths.push(await persistInboundImage(img, project!));
+		} catch (e) {
+			console.warn(`[runner] persist image failed: ${String(e)}`);
+		}
+	}
+	const attachmentNote = savedPaths.length
+		? `\n[图片已保存到] ${savedPaths.join(", ")}（可在记录中引用这些相对路径）`
+		: "";
+	const execText = `${userMessage}${attachmentNote}`.trim();
 
 	// Phase 2: execution
 	const systemPrompt = loadSystemPrompt(project);
@@ -370,7 +403,9 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 	setTaskContext(ctx.recipient ? { recipient: ctx.recipient } : null);
 	try {
 		markAgentStart();
-		await agent.prompt(userMessage);
+		// Inline vision (decoded bytes) + the saved-path note, so the model can both see the
+		// image and reference its persisted location in the data file.
+		await agent.prompt(execText, toImageContent(inboundImages));
 	} finally {
 		markAgentEnd();
 		setTaskContext(null);
@@ -414,13 +449,17 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 			`To raise the limit, set MAX_TOOL_TURNS in .env (default 20).`;
 	}
 
-	// Whether a data file was modified: scan toolResult messages for the toolName
-	const mutated = state.messages.some(
-		(m) =>
-			m.role === "toolResult" &&
-			typeof (m as { toolName?: string }).toolName === "string" &&
-			["write", "edit"].includes((m as { toolName: string }).toolName),
-	);
+	// Whether a data file was modified: scan toolResult messages for the toolName, or whether
+	// inbound images were persisted (so the photo is committed promptly rather than riding the
+	// next commit of this subproject).
+	const mutated =
+		savedPaths.length > 0 ||
+		state.messages.some(
+			(m) =>
+				m.role === "toolResult" &&
+				typeof (m as { toolName?: string }).toolName === "string" &&
+				["write", "edit"].includes((m as { toolName: string }).toolName),
+		);
 
 	const endedAt = Date.now();
 	const log = collectTaskLog({
@@ -437,6 +476,7 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 		replyText: text,
 		images,
 		mutated,
+		inboundImageCount: inboundImages.length,
 		messages: state.messages,
 		routingUsage,
 		routing: { candidates: routingCandidates, decision: project, prompt: routingPrompt },


### PR DESCRIPTION
## Summary

Implements `docs/design/wechat-inbound-image.md`: the WeChat (iLink) channel can now receive images from users, feed them to the model as **inline vision input**, and persist the original under the target data subproject so records can reference the photo.

Driving scenario: a `cook` subproject where the user photographs a meal, the agent recognizes the food, and appends a `meals.jsonl` record (`kcal` + macros) with a `photo` field pointing at the saved relative path.

## Changes

- **`src/channels/wechat/download.ts`** (new): `downloadInboundImage` (CDN fetch with timeout + retry → AES-128-ECB decrypt → magic-byte `sniffMime`), `persistInboundImage` (writes `DATA_ROOT/<project>/photos/<date>-<rand>.<ext>` via `safePath` + image-extension whitelist), `InboundImage` type.
- **`src/channels/wechat/aes-ecb.ts`**: added `decryptAesEcb` + tolerant `parseInboundAesKey` (hex / base64-raw-16 / base64-of-hex-32, strict validation).
- **`src/channels/wechat/upload.ts`**: exported `CDN_BASE_URL` for reuse.
- **`src/channels/wechat/monitor.ts`**: decodes IMAGE items best-effort **after the sender allowlist check**; image-only messages route via the `[图片]` placeholder instead of being dropped; dedup id folds in a hash of the decoded bytes so consecutive photos are dedup-safe.
- **`src/dispatcher.ts`**: `DispatchOptions.inboundImages?` forwarded to `runTask`.
- **`src/runner.ts`**: skips the greeting short-circuit when images are present, passes vision to routing, persists originals only after a subproject is known (never for unrouted/unknown/`__scheduler__`), appends a saved-path note to the prompt, feeds inline vision, counts persisted photos as `mutated`, logs `inboundImageCount`.
- **`src/logging/types.ts` + `src/logging/collect.ts`**: optional `inboundImageCount` on `TaskLog`.
- **`src/prompts/system-prompt.ts`**: exported `today()` (local-tz date) for consistent photo file naming.
- **Tests**: `aes-ecb.test.ts` + `download.test.ts` (decrypt round-trip, key parsing variants, mime sniff, persist path/escape), wired into `npm test`.

## Security boundary

- Persisted originals are written only through `persistInboundImage`, routed through `safePath` (first-level subdir allowlist) + an image-extension whitelist — the file can never escape `DATA_ROOT`.
- The agent only ever receives the saved **relative path as text**; no new tool/bash capability is added, `safePath` is never relaxed.
- Unauthorized senders never trigger a CDN download/decrypt.
- A single bad image is warn-logged and skipped; the long-poll loop keeps running.

## Verification

- `npm run typecheck` passes.
- `npm test`: all 92 tests pass (incl. 17 new for AES key parsing, mime sniff, and persistence).
- Manual CDN download+decrypt path to be verified from a real WeChat account (protocol cross-checked against `weixin-agent-sdk` and `openilink-sdk-go`).