### PR TITLE
fix(webui): address scheduler history review feedback

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"restart": "bash scripts/botlerctl.sh restart",
 		"init": "tsx src/init.ts",
 		"typecheck": "tsc --noEmit",
-		"test": "tsx --test src/scheduler/cron.test.ts src/scheduler/store.test.ts src/monitor/stats.test.ts src/greeting.test.ts src/channels/wechat/aes-ecb.test.ts src/channels/wechat/download.test.ts src/channels/wechat/image-batch.test.ts",
+		"test": "tsx --test src/scheduler/cron.test.ts src/scheduler/store.test.ts src/logging/store.test.ts src/monitor/stats.test.ts src/greeting.test.ts src/channels/wechat/aes-ecb.test.ts src/channels/wechat/download.test.ts src/channels/wechat/image-batch.test.ts",
 		"webui": "tsx src/webui/server.ts",
 		"cli": "tsx src/index.ts"
 	},

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"restart": "bash scripts/botlerctl.sh restart",
 		"init": "tsx src/init.ts",
 		"typecheck": "tsc --noEmit",
-		"test": "tsx --test src/scheduler/cron.test.ts src/scheduler/store.test.ts src/logging/store.test.ts src/monitor/stats.test.ts src/greeting.test.ts src/channels/wechat/aes-ecb.test.ts src/channels/wechat/download.test.ts src/channels/wechat/image-batch.test.ts",
+		"test": "tsx --test src/scheduler/cron.test.ts src/scheduler/store.test.ts src/scheduler/history.test.ts src/logging/store.test.ts src/monitor/stats.test.ts src/greeting.test.ts src/channels/wechat/aes-ecb.test.ts src/channels/wechat/download.test.ts src/channels/wechat/image-batch.test.ts",
 		"webui": "tsx src/webui/server.ts",
 		"cli": "tsx src/index.ts"
 	},

--- a/src/logging/store.test.ts
+++ b/src/logging/store.test.ts
@@ -1,0 +1,93 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { filterAndPageLogs, matchesLogQuery, scheduleIdFromTaskId } from "./store.ts";
+import type { TaskLog } from "./types.ts";
+
+function makeLog(overrides: Partial<TaskLog> = {}): TaskLog {
+	return {
+		id: "log-1",
+		taskId: "schedule:foo:1720000000000",
+		phase: "execute",
+		source: "scheduler",
+		provider: "test",
+		model: "test",
+		project: null,
+		status: "success",
+		startedAt: 1720000000000,
+		endedAt: 1720000001000,
+		durationMs: 1000,
+		userMessage: "run schedule",
+		replyText: "ok",
+		images: [],
+		mutated: false,
+		tools: [],
+		conversation: [],
+		usage: { input: 10, output: 1, cacheRead: 0, cacheWrite: 0, total: 11, costUsd: 0 },
+		calls: [],
+		modelCache: { queries: 1, hits: 0, hitRate: 0 },
+		...overrides,
+	};
+}
+
+test("scheduleIdFromTaskId extracts a normal schedule id", () => {
+	assert.equal(scheduleIdFromTaskId("schedule:drink-water:1720000000000"), "drink-water");
+});
+
+test("scheduleIdFromTaskId supports colon in the schedule id", () => {
+	assert.equal(scheduleIdFromTaskId("schedule:foo:bar:1720000000000"), "foo:bar");
+});
+
+test("scheduleIdFromTaskId ignores non-scheduler task ids", () => {
+	assert.equal(scheduleIdFromTaskId("telegram:123:456"), undefined);
+	assert.equal(scheduleIdFromTaskId("random-task-id"), undefined);
+});
+
+test("matchesLogQuery filters scheduler logs by scheduleId", () => {
+	const q = { source: "scheduler", scheduleId: "foo:bar" };
+	assert.equal(matchesLogQuery(makeLog({ taskId: "schedule:foo:bar:1720000000000" }), q), true);
+	assert.equal(matchesLogQuery(makeLog({ taskId: "schedule:other:1720000000000" }), q), false);
+});
+
+test("matchesLogQuery filters by phase", () => {
+	const q = { source: "scheduler", scheduleId: "foo", phase: "execute" as const };
+	assert.equal(matchesLogQuery(makeLog({ phase: "execute" }), q), true);
+	assert.equal(matchesLogQuery(makeLog({ phase: "self-heal" }), q), false);
+});
+
+test("filterAndPageLogs filters by scheduleId and handles ids containing a colon", () => {
+	const logs = [
+		makeLog({ taskId: "schedule:foo:bar:1720000003000", startedAt: 1720000003000 }),
+		makeLog({ taskId: "schedule:foo:bar:1720000001000", startedAt: 1720000001000 }),
+		makeLog({ taskId: "schedule:other:1720000002000", startedAt: 1720000002000 }),
+	];
+
+	const page = filterAndPageLogs(logs, {
+		source: "scheduler",
+		scheduleId: "foo:bar",
+		limit: 1,
+		offset: 0,
+	});
+
+	assert.equal(page.total, 2);
+	assert.equal(page.logs.length, 1);
+	assert.equal(page.logs[0].taskId, "schedule:foo:bar:1720000003000");
+});
+
+test("filterAndPageLogs pages past the first match without changing total", () => {
+	const logs = [
+		makeLog({ taskId: "schedule:foo:1720000003000", startedAt: 1720000003000 }),
+		makeLog({ taskId: "schedule:foo:1720000002000", startedAt: 1720000002000 }),
+		makeLog({ taskId: "schedule:foo:1720000001000", startedAt: 1720000001000 }),
+	];
+
+	const page = filterAndPageLogs(logs, {
+		source: "scheduler",
+		scheduleId: "foo",
+		limit: 1,
+		offset: 1,
+	});
+
+	assert.equal(page.total, 3);
+	assert.equal(page.logs.length, 1);
+	assert.equal(page.logs[0].taskId, "schedule:foo:1720000002000");
+});

--- a/src/logging/store.ts
+++ b/src/logging/store.ts
@@ -42,6 +42,8 @@ export interface LogQuery {
 	to?: number;
 	project?: string;
 	source?: string;
+	scheduleId?: string;
+	phase?: TaskLog["phase"];
 	q?: string;
 	limit?: number;
 	offset?: number;
@@ -51,6 +53,35 @@ export interface LogPage {
 	logs: TaskLog[];
 	total: number;
 }
+
+/**
+ * Scheduler dispatches use taskId `schedule:<id>:<epoch>`. Use a greedy capture so ids that
+ * themselves contain ":" are extracted correctly.
+ */
+export function scheduleIdFromTaskId(taskId: string): string | undefined {
+	const m = /^schedule:(.+):\d+$/.exec(taskId);
+	return m?.[1];
+}
+
+export function matchesLogQuery(log: TaskLog, q: LogQuery): boolean {
+	if (q.project && log.project !== q.project) return false;
+	if (q.source && log.source !== q.source) return false;
+	if (q.phase && log.phase !== q.phase) return false;
+	if (q.scheduleId && scheduleIdFromTaskId(log.taskId) !== q.scheduleId) return false;
+	if (q.q) {
+		const needle = q.q.toLowerCase();
+		if (
+			!log.userMessage.toLowerCase().includes(needle) &&
+			!log.replyText.toLowerCase().includes(needle) &&
+			!(log.project ?? "").toLowerCase().includes(needle)
+		) {
+			return false;
+		}
+	}
+	return true;
+}
+
+export type LogScan = Omit<LogQuery, "limit" | "offset">;
 
 function loadDayFile(file: string): TaskLog[] {
 	const abs = join(CONFIG.logDir, file);
@@ -83,23 +114,29 @@ function dayFilesInRange(from?: number, to?: number): string[] {
 	return files.sort().reverse();
 }
 
-export function queryLogs(q: LogQuery): LogPage {
-	const files = dayFilesInRange(q.from, q.to);
-	const all: TaskLog[] = [];
-	for (const f of files) all.push(...loadDayFile(f));
-
-	let filtered = all;
-	if (q.project) filtered = filtered.filter((l) => l.project === q.project);
-	if (q.source) filtered = filtered.filter((l) => l.source === q.source);
-	if (q.q) {
-		const needle = q.q.toLowerCase();
-		filtered = filtered.filter(
-			(l) =>
-				l.userMessage.toLowerCase().includes(needle) ||
-				l.replyText.toLowerCase().includes(needle) ||
-				(l.project ?? "").toLowerCase().includes(needle),
-		);
+/**
+ * Single-pass visitor for aggregation paths. It still reads each day file, but does not keep
+ * every matching TaskLog in memory.
+ *
+ * V1 deliberately reuses loadDayFile(), which currently materializes one day's file as a
+ * TaskLog[] via readFileSync. That caps memory at the largest single-day file, not the whole
+ * history, and matches the existing WebUI log query. If a future install produces very large
+ * single-day files, replace this with a line-streaming reader without changing call sites.
+ */
+export function scanLogs(q: LogScan, visit: (log: TaskLog) => void): void {
+	for (const f of dayFilesInRange(q.from, q.to)) {
+		for (const l of loadDayFile(f)) {
+			if (matchesLogQuery(l, q)) visit(l);
+		}
 	}
+}
+
+/**
+ * Pure filter/sort/page helper. Kept separate from the file reading so the schedule filtering
+ * logic can be tested with fixture TaskLog[] values without touching CONFIG.logDir.
+ */
+export function filterAndPageLogs(all: TaskLog[], q: LogQuery): LogPage {
+	const filtered = all.filter((l) => matchesLogQuery(l, q));
 
 	// Already sorted desc by file; stable sort by startedAt desc to be safe across a day boundary.
 	filtered.sort((a, b) => b.startedAt - a.startedAt);
@@ -109,6 +146,13 @@ export function queryLogs(q: LogQuery): LogPage {
 	const limit = q.limit ?? 50;
 	const logs = filtered.slice(offset, offset + limit);
 	return { logs, total };
+}
+
+export function queryLogs(q: LogQuery): LogPage {
+	const files = dayFilesInRange(q.from, q.to);
+	const all: TaskLog[] = [];
+	for (const f of files) all.push(...loadDayFile(f));
+	return filterAndPageLogs(all, q);
 }
 
 export function getLog(id: string): TaskLog | undefined {

--- a/src/scheduler/history.test.ts
+++ b/src/scheduler/history.test.ts
@@ -1,0 +1,159 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+	aggregateRunStats,
+	scheduleOverviewFromLogs,
+} from "./history.ts";
+import type { TaskLog } from "../logging/types.ts";
+import type { ScheduleEntry } from "./types.ts";
+
+function makeLog(overrides: Partial<TaskLog> = {}): TaskLog {
+	return {
+		id: "log-1",
+		taskId: "schedule:foo:1720000000000",
+		phase: "execute",
+		source: "scheduler",
+		provider: "test",
+		model: "test",
+		project: "notes",
+		status: "success",
+		startedAt: 1720000000000,
+		endedAt: 1720000001000,
+		durationMs: 1000,
+		userMessage: "run schedule",
+		replyText: "ok",
+		images: [],
+		mutated: false,
+		tools: [],
+		conversation: [],
+		usage: { input: 10, output: 1, cacheRead: 0, cacheWrite: 0, total: 11, costUsd: 0 },
+		calls: [],
+		modelCache: { queries: 1, hits: 0, hitRate: 0 },
+		...overrides,
+	};
+}
+
+function makeEntry(overrides: Partial<ScheduleEntry> = {}): ScheduleEntry {
+	return {
+		id: "foo",
+		enabled: false,
+		timezone: "Asia/Shanghai",
+		message: "run it",
+		interval: "1h",
+		project: "notes",
+		retry: { max: 2, backoffMs: 1000 },
+		silentHours: { from: "22:00", to: "07:00" },
+		holidayMode: "workday",
+		recipient: { source: "telegram", userId: "chat-1" },
+		...overrides,
+	};
+}
+
+test("aggregateRunStats handles an empty log stream", () => {
+	const stats = aggregateRunStats("empty", (visit) => {
+		// No logs visited.
+	});
+
+	assert.equal(stats.scheduleId, "empty");
+	assert.equal(stats.totalRuns, 0);
+	assert.deepEqual(stats.byStatus, {});
+	assert.equal(stats.firstRunAt, null);
+	assert.equal(stats.lastRunAt, null);
+	assert.equal(stats.avgDurationMs, 0);
+	assert.deepEqual(stats.token, { input: 0, output: 0, total: 0 });
+});
+
+test("aggregateRunStats sums tokens, durations, and statuses", () => {
+	const logs = [
+		makeLog({
+			id: "a",
+			status: "success",
+			startedAt: 1720000000000,
+			durationMs: 100,
+			usage: { input: 10, output: 2, cacheRead: 0, cacheWrite: 0, total: 12, costUsd: 0 },
+		}),
+		makeLog({
+			id: "b",
+			status: "error",
+			startedAt: 1720000100000,
+			durationMs: 250,
+			usage: { input: 20, output: 3, cacheRead: 0, cacheWrite: 0, total: 23, costUsd: 0 },
+		}),
+		makeLog({
+			id: "c",
+			status: "validation-failed",
+			startedAt: 1720000050000,
+			durationMs: 400,
+			usage: { input: 30, output: 4, cacheRead: 0, cacheWrite: 0, total: 34, costUsd: 0 },
+		}),
+	];
+
+	const stats = aggregateRunStats("foo", (visit) => logs.forEach(visit));
+
+	assert.equal(stats.totalRuns, 3);
+	assert.deepEqual(stats.byStatus, {
+		success: 1,
+		error: 1,
+		"validation-failed": 1,
+	});
+	assert.equal(stats.firstRunAt, 1720000000000);
+	assert.equal(stats.lastRunAt, 1720000100000);
+	assert.equal(stats.avgDurationMs, 250);
+	assert.deepEqual(stats.token, { input: 60, output: 9, total: 69 });
+});
+
+test("scheduleOverviewFromLogs preserves entry fields and picks the latest run", () => {
+	const entries = [
+		makeEntry({ id: "foo" }),
+		makeEntry({ id: "bar", enabled: false, timezone: "UTC", message: "bar" }),
+	];
+	const logs = [
+		makeLog({
+			id: "older",
+			taskId: "schedule:foo:1720000000000",
+			status: "error",
+			startedAt: 1720000000000,
+			durationMs: 900,
+			project: "notes",
+			usage: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0, total: 3, costUsd: 0 },
+		}),
+		makeLog({
+			id: "newer",
+			taskId: "schedule:foo:1720000100000",
+			status: "success",
+			startedAt: 1720000100000,
+			durationMs: 100,
+			project: "notes",
+			usage: { input: 4, output: 5, cacheRead: 0, cacheWrite: 0, total: 9, costUsd: 0 },
+		}),
+		makeLog({
+			id: "other",
+			taskId: "telegram:123:456",
+			status: "success",
+			startedAt: 1720000200000,
+		}),
+	];
+
+	const overview = scheduleOverviewFromLogs(entries, logs);
+	const foo = overview.find((e) => e.id === "foo");
+	const bar = overview.find((e) => e.id === "bar");
+
+	assert.ok(foo);
+	assert.equal(foo.interval, "1h");
+	assert.equal(foo.project, "notes");
+	assert.deepEqual(foo.retry, { max: 2, backoffMs: 1000 });
+	assert.deepEqual(foo.silentHours, { from: "22:00", to: "07:00" });
+	assert.equal(foo.holidayMode, "workday");
+	assert.deepEqual(foo.recipient, { source: "telegram", userId: "chat-1" });
+	assert.equal(foo.nextFireAt, null);
+	assert.deepEqual(foo.lastRun, {
+		startedAt: 1720000100000,
+		status: "success",
+		durationMs: 100,
+		project: "notes",
+		tokenTotal: 9,
+	});
+
+	assert.ok(bar);
+	assert.equal(bar.lastRun, null);
+});

--- a/src/scheduler/history.ts
+++ b/src/scheduler/history.ts
@@ -1,0 +1,145 @@
+/**
+ * Read-only scheduler history queries for the WebUI.
+ *
+ * V1 derives history from the existing task-log store: scheduler dispatches are written with
+ * source "scheduler" and taskId "schedule:<id>:<epoch>". This keeps one execution record format
+ * and avoids a second persistent history file.
+ */
+
+import { nextFireEpoch } from "./cron.ts";
+import { loadSchedules } from "./store.ts";
+import {
+	queryLogs,
+	scanLogs,
+	scheduleIdFromTaskId,
+	type LogQuery,
+	type LogPage,
+} from "../logging/store.ts";
+import type { TaskLog } from "../logging/types.ts";
+import type { ScheduleEntry } from "./types.ts";
+
+export type ScheduleRunQuery = Pick<LogQuery, "from" | "to" | "q" | "limit" | "offset">;
+
+export interface ScheduleRunStats {
+	scheduleId: string;
+	totalRuns: number;
+	byStatus: Record<string, number>;
+	firstRunAt: number | null;
+	lastRunAt: number | null;
+	avgDurationMs: number;
+	token: { input: number; output: number; total: number };
+}
+
+export interface ScheduleLastRun {
+	startedAt: number;
+	status: TaskLog["status"];
+	durationMs: number;
+	project: string | null;
+	tokenTotal: number;
+}
+
+export interface ScheduleOverviewItem {
+	id: string;
+	enabled: boolean;
+	cron?: string;
+	interval?: string;
+	at?: string;
+	once?: string;
+	timezone: string;
+	message: string;
+	project?: string;
+	retry?: ScheduleEntry["retry"];
+	silentHours?: ScheduleEntry["silentHours"];
+	holidayMode?: ScheduleEntry["holidayMode"];
+	recipient?: ScheduleEntry["recipient"];
+	nextFireAt: number | null;
+	lastRun: ScheduleLastRun | null;
+}
+
+function nextFireAt(e: ScheduleEntry): number | null {
+	if (!e.enabled) return null;
+	try {
+		const next = nextFireEpoch(e, Date.now());
+		return next === Infinity ? null : next;
+	} catch {
+		return null;
+	}
+}
+
+export function scheduleRuns(id: string, q: ScheduleRunQuery = {}): LogPage {
+	return queryLogs({ ...q, source: "scheduler", scheduleId: id });
+}
+
+export function scheduleRunStats(id: string): ScheduleRunStats {
+	const byStatus: Record<string, number> = {};
+	const token = { input: 0, output: 0, total: 0 };
+	let durationSum = 0;
+	let firstRunAt: number | null = null;
+	let lastRunAt: number | null = null;
+	let totalRuns = 0;
+
+	scanLogs({ source: "scheduler", scheduleId: id, phase: "execute" }, (l) => {
+		totalRuns += 1;
+		byStatus[l.status] = (byStatus[l.status] ?? 0) + 1;
+		token.input += l.usage.input;
+		token.output += l.usage.output;
+		token.total += l.usage.total;
+		durationSum += l.durationMs;
+		firstRunAt = firstRunAt === null ? l.startedAt : Math.min(firstRunAt, l.startedAt);
+		lastRunAt = lastRunAt === null ? l.startedAt : Math.max(lastRunAt, l.startedAt);
+	});
+
+	return {
+		scheduleId: id,
+		totalRuns,
+		byStatus,
+		firstRunAt,
+		lastRunAt,
+		avgDurationMs: totalRuns ? Math.round(durationSum / totalRuns) : 0,
+		token,
+	};
+}
+
+export function scheduleOverview(): ScheduleOverviewItem[] {
+	const entries = loadSchedules();
+	const latest = new Map<string, TaskLog>();
+
+	scanLogs({ source: "scheduler", phase: "execute" }, (l) => {
+		const scheduleId = scheduleIdFromTaskId(l.taskId);
+		if (!scheduleId) return;
+		const prev = latest.get(scheduleId);
+		if (!prev || l.startedAt > prev.startedAt) latest.set(scheduleId, l);
+	});
+
+	const toLastRun = (l: TaskLog | undefined): ScheduleLastRun | null =>
+		l
+			? {
+					startedAt: l.startedAt,
+					status: l.status,
+					durationMs: l.durationMs,
+					project: l.project,
+					tokenTotal: l.usage.total,
+				}
+			: null;
+
+	return entries.map((e) => {
+		const last = latest.get(e.id);
+		return {
+			id: e.id,
+			enabled: e.enabled,
+			timezone: e.timezone,
+			message: e.message,
+			...(e.cron ? { cron: e.cron } : {}),
+			...(e.interval ? { interval: e.interval } : {}),
+			...(e.at ? { at: e.at } : {}),
+			...(e.once ? { once: e.once } : {}),
+			...(e.project ? { project: e.project } : {}),
+			...(e.retry ? { retry: e.retry } : {}),
+			...(e.silentHours ? { silentHours: e.silentHours } : {}),
+			...(e.holidayMode ? { holidayMode: e.holidayMode } : {}),
+			...(e.recipient ? { recipient: e.recipient } : {}),
+			nextFireAt: nextFireAt(e),
+			lastRun: toLastRun(last),
+		};
+	});
+}

--- a/src/scheduler/history.ts
+++ b/src/scheduler/history.ts
@@ -38,23 +38,12 @@ export interface ScheduleLastRun {
 	tokenTotal: number;
 }
 
-export interface ScheduleOverviewItem {
-	id: string;
-	enabled: boolean;
-	cron?: string;
-	interval?: string;
-	at?: string;
-	once?: string;
-	timezone: string;
-	message: string;
-	project?: string;
-	retry?: ScheduleEntry["retry"];
-	silentHours?: ScheduleEntry["silentHours"];
-	holidayMode?: ScheduleEntry["holidayMode"];
-	recipient?: ScheduleEntry["recipient"];
+export type ScheduleOverviewItem = ScheduleEntry & {
 	nextFireAt: number | null;
 	lastRun: ScheduleLastRun | null;
-}
+};
+
+export type RunLogVisitor = (visit: (log: TaskLog) => void) => void;
 
 function nextFireAt(e: ScheduleEntry): number | null {
 	if (!e.enabled) return null;
@@ -70,7 +59,10 @@ export function scheduleRuns(id: string, q: ScheduleRunQuery = {}): LogPage {
 	return queryLogs({ ...q, source: "scheduler", scheduleId: id });
 }
 
-export function scheduleRunStats(id: string): ScheduleRunStats {
+export function aggregateRunStats(
+	scheduleId: string,
+	iterate: RunLogVisitor,
+): ScheduleRunStats {
 	const byStatus: Record<string, number> = {};
 	const token = { input: 0, output: 0, total: 0 };
 	let durationSum = 0;
@@ -78,7 +70,7 @@ export function scheduleRunStats(id: string): ScheduleRunStats {
 	let lastRunAt: number | null = null;
 	let totalRuns = 0;
 
-	scanLogs({ source: "scheduler", scheduleId: id, phase: "execute" }, (l) => {
+	iterate((l) => {
 		totalRuns += 1;
 		byStatus[l.status] = (byStatus[l.status] ?? 0) + 1;
 		token.input += l.usage.input;
@@ -90,7 +82,7 @@ export function scheduleRunStats(id: string): ScheduleRunStats {
 	});
 
 	return {
-		scheduleId: id,
+		scheduleId,
 		totalRuns,
 		byStatus,
 		firstRunAt,
@@ -98,6 +90,55 @@ export function scheduleRunStats(id: string): ScheduleRunStats {
 		avgDurationMs: totalRuns ? Math.round(durationSum / totalRuns) : 0,
 		token,
 	};
+}
+
+export function scheduleRunStats(id: string): ScheduleRunStats {
+	return aggregateRunStats(id, (visit) => {
+		scanLogs({ source: "scheduler", scheduleId: id, phase: "execute" }, visit);
+	});
+}
+
+function toLastRun(l: TaskLog | undefined): ScheduleLastRun | null {
+	return l
+		? {
+				startedAt: l.startedAt,
+				status: l.status,
+				durationMs: l.durationMs,
+				project: l.project,
+				tokenTotal: l.usage.total,
+			}
+		: null;
+}
+
+function latestRunBySchedule(logs: Iterable<TaskLog>): Map<string, TaskLog> {
+	const latest = new Map<string, TaskLog>();
+
+	for (const l of logs) {
+		const scheduleId = scheduleIdFromTaskId(l.taskId);
+		if (!scheduleId) continue;
+		const prev = latest.get(scheduleId);
+		if (!prev || l.startedAt > prev.startedAt) latest.set(scheduleId, l);
+	}
+
+	return latest;
+}
+
+function buildScheduleOverview(
+	entries: ScheduleEntry[],
+	latest: Map<string, TaskLog>,
+): ScheduleOverviewItem[] {
+	return entries.map((e) => ({
+		...e,
+		nextFireAt: nextFireAt(e),
+		lastRun: toLastRun(latest.get(e.id)),
+	}));
+}
+
+export function scheduleOverviewFromLogs(
+	entries: ScheduleEntry[],
+	logs: Iterable<TaskLog>,
+): ScheduleOverviewItem[] {
+	return buildScheduleOverview(entries, latestRunBySchedule(logs));
 }
 
 export function scheduleOverview(): ScheduleOverviewItem[] {
@@ -111,35 +152,5 @@ export function scheduleOverview(): ScheduleOverviewItem[] {
 		if (!prev || l.startedAt > prev.startedAt) latest.set(scheduleId, l);
 	});
 
-	const toLastRun = (l: TaskLog | undefined): ScheduleLastRun | null =>
-		l
-			? {
-					startedAt: l.startedAt,
-					status: l.status,
-					durationMs: l.durationMs,
-					project: l.project,
-					tokenTotal: l.usage.total,
-				}
-			: null;
-
-	return entries.map((e) => {
-		const last = latest.get(e.id);
-		return {
-			id: e.id,
-			enabled: e.enabled,
-			timezone: e.timezone,
-			message: e.message,
-			...(e.cron ? { cron: e.cron } : {}),
-			...(e.interval ? { interval: e.interval } : {}),
-			...(e.at ? { at: e.at } : {}),
-			...(e.once ? { once: e.once } : {}),
-			...(e.project ? { project: e.project } : {}),
-			...(e.retry ? { retry: e.retry } : {}),
-			...(e.silentHours ? { silentHours: e.silentHours } : {}),
-			...(e.holidayMode ? { holidayMode: e.holidayMode } : {}),
-			...(e.recipient ? { recipient: e.recipient } : {}),
-			nextFireAt: nextFireAt(e),
-			lastRun: toLastRun(last),
-		};
-	});
+	return buildScheduleOverview(entries, latest);
 }

--- a/src/webui/index.html
+++ b/src/webui/index.html
@@ -107,7 +107,7 @@
   .field .verr { color:var(--err); font-size:11px; }
   .banner { background:var(--warn-bg); border:1px solid var(--warn); color:var(--warn-fg); border-radius:8px; padding:10px 14px; margin-bottom:14px; font-size:13px; display:none; }
   textarea.code { font-family:var(--font-mono); min-height:340px; width:100%; background:var(--panel2); border:1px solid var(--line); color:var(--fg); border-radius:8px; padding:10px; font-size:12.5px; line-height:1.5; }
-  .sched-row { display:grid; grid-template-columns:auto 160px 1fr 150px auto; gap:10px; align-items:center; padding:8px 0; border-bottom:1px solid var(--line); }
+  .sched-row { display:grid; grid-template-columns:auto 150px minmax(180px,1fr) 150px 150px auto; gap:10px; align-items:center; padding:8px 0; border-bottom:1px solid var(--line); }
   .sched-summary { font-size:12px; color:var(--muted); }
   .eye { background:#fff; border:1px solid var(--line); color:var(--fg); border-radius:6px; padding:4px 8px; cursor:pointer; font-size:12px; }
 
@@ -162,6 +162,7 @@
     <span class="host" id="host"></span>
     <div class="view-switch" role="tablist">
       <button type="button" class="view-btn active" data-view="logs-view">Task logs</button>
+      <button type="button" class="view-btn" data-view="schedules-view">Schedules</button>
       <button type="button" class="view-btn" data-view="stats-view">Stats</button>
       <button type="button" class="view-btn" data-view="monitor-view">Monitor</button>
       <button type="button" class="view-btn" data-view="config-view">Config</button>
@@ -188,6 +189,18 @@
         <div id="disk-summary"></div>
         <div id="disk-files"></div>
       </div>
+    </div>
+
+    <!-- ============ SCHEDULES VIEW ============ -->
+    <div id="schedules-view" class="wrap" style="display:none">
+      <div class="cards" id="sched-cards"></div>
+      <div class="muted" style="margin:0 0 12px;font-size:12px">History is retained as long as task logs are kept.</div>
+      <div class="row-actions" style="margin-bottom:10px">
+        <button class="btn" id="sched-add">+ Add</button>
+        <button class="btn ghost" id="sched-reload">Refresh</button>
+      </div>
+      <div id="sched-list"></div>
+      <div id="sched-history" style="display:none"></div>
     </div>
 
     <!-- ============ STATS VIEW ============ -->
@@ -224,16 +237,6 @@
           <button class="btn ghost" id="wx-refresh">Refresh</button>
         </div>
         <div id="wechat-status"></div>
-      </div>
-
-      <div class="panel">
-        <h2>Scheduled tasks</h2>
-        <div class="hint">At fire time, builds a message into dispatch (reusing dedup / queue / validation / commit). Takes effect immediately.</div>
-        <div class="row-actions" style="margin-bottom:10px">
-          <button class="btn" id="sched-add">+ Add</button>
-          <button class="btn ghost" id="sched-reload">Refresh</button>
-        </div>
-        <div id="sched-list"></div>
       </div>
 
       <div class="panel">
@@ -301,6 +304,7 @@ document.querySelectorAll(".view-btn").forEach(btn=>btn.onclick=()=>{
   document.querySelectorAll(".view-btn").forEach(x=>x.classList.remove("active"));
   btn.classList.add("active");
   document.getElementById("logs-view").style.display = btn.dataset.view==="logs-view"?"block":"none";
+  document.getElementById("schedules-view").style.display = btn.dataset.view==="schedules-view"?"block":"none";
   document.getElementById("stats-view").style.display = btn.dataset.view==="stats-view"?"block":"none";
   document.getElementById("monitor-view").style.display = btn.dataset.view==="monitor-view"?"block":"none";
   document.getElementById("config-view").style.display = btn.dataset.view==="config-view"?"block":"none";
@@ -308,6 +312,7 @@ document.querySelectorAll(".view-btn").forEach(btn=>btn.onclick=()=>{
   clearInterval(monitorTimer);
   monitorTimer = null;
   if(btn.dataset.view==="config-view") loadConfig();
+  if(btn.dataset.view==="schedules-view") loadSchedulesView();
   if(btn.dataset.view==="stats-view") loadStats();
   if(btn.dataset.view==="monitor-view") startMonitorTimer();
 });
@@ -775,60 +780,156 @@ document.getElementById("sp-save").onclick = async ()=>{
 };
 
 // ---- schedules ----
+let schedHistory = { id: null, offset: 0, limit: 20, total: 0 };
+
 function scheduleSummary(e){
   if(e.cron) return "cron: "+e.cron;
   if(e.interval) return "interval: "+e.interval;
   if(e.at) return "at: "+e.at+" (daily)";
-  if(e.once) return "once: "+e.once;
+  if(e.once){
+    const d = new Date(e.once);
+    return "once: " + (isNaN(d.getTime()) ? e.once : d.toLocaleString());
+  }
   return "(no trigger)";
 }
-function renderSchedules(lastExec){
-  if(!schedules.length){ document.getElementById("sched-list").innerHTML='<div class="muted">No scheduled tasks yet. Click "Add" to create one.</div>'; return; }
+
+function renderScheduleCards(){
+  const total = schedules.length;
+  const enabled = schedules.filter(e=>e.enabled).length;
+  const withNext = schedules.filter(e=>e.nextFireAt).length;
+  document.getElementById("sched-cards").innerHTML = [
+    ["Total", total],
+    ["Enabled", enabled],
+    ["Scheduled", withNext],
+    ["Disabled", total-enabled]
+  ].map(([k,v])=>`<div class="card"><div class="k">${k}</div><div class="v">${v}</div></div>`).join("");
+}
+
+function renderSchedules(){
+  if(!schedules.length){
+    document.getElementById("sched-list").innerHTML='<div class="muted">No scheduled tasks yet. Click "Add" to create one.</div>';
+    return;
+  }
   document.getElementById("sched-list").innerHTML = schedules.map(e=>{
-    const last = lastExec[e.id];
-    const lastStr = last? `${fmtTime(last.startedAt)} · ${statusBadge(last.status)}` : "—";
+    const last = e.lastRun
+      ? `${fmtTime(e.lastRun.startedAt)} · ${statusBadge(e.lastRun.status)}`
+      : "—";
+    const next = e.nextFireAt ? `${fmtTime(e.nextFireAt)}` : "—";
     return `<div class="sched-row">
       <label><input type="checkbox" class="sched-enable" data-id="${esc(e.id)}" ${e.enabled?"checked":""}/> ${esc(e.id)}</label>
       <div class="sched-summary">${esc(scheduleSummary(e))}<br/>tz:${esc(e.timezone||"Asia/Shanghai")}${e.project?("<br/>project:"+esc(e.project)):""}</div>
       <div class="sched-summary">${esc((e.message||"").slice(0,60))}</div>
-      <div class="muted" style="font-size:12px">Last: ${lastStr}</div>
+      <div class="muted" style="font-size:12px">Next: ${next}</div>
+      <div class="muted" style="font-size:12px">Last: ${last}</div>
       <div class="row-actions">
+        <button class="btn ghost sched-history" data-id="${esc(e.id)}">History</button>
         <button class="btn ghost sched-edit" data-id="${esc(e.id)}">Edit</button>
         <button class="btn danger sched-del" data-id="${esc(e.id)}">Delete</button>
       </div>
     </div>`;
   }).join("");
+
   document.querySelectorAll(".sched-enable").forEach(c=>c.onchange=async()=>{
     const id=c.dataset.id; const e=schedules.find(x=>x.id===id); if(!e) return;
-    e.enabled = c.checked;
+    e.enabled=c.checked;
     await persistSchedules();
   });
+  document.querySelectorAll(".sched-history").forEach(b=>b.onclick=()=>openSchedHistory(b.dataset.id));
   document.querySelectorAll(".sched-edit").forEach(b=>b.onclick=()=>openSchedModal(b.dataset.id));
   document.querySelectorAll(".sched-del").forEach(b=>b.onclick=async()=>{
     if(!confirm("Confirm deleting scheduled task "+b.dataset.id+"?")) return;
-    schedules = schedules.filter(x=>x.id!==b.dataset.id);
+    schedules=schedules.filter(x=>x.id!==b.dataset.id);
     await persistSchedules();
   });
 }
-async function persistSchedules(){
-  try { const r = await cfgWrite("/api/config/schedules", { schedules }); if(r.error) return toast("Error: "+r.error); toast("Saved; takes effect immediately"); await loadSchedulesView(); }
-  catch(e){ toast("Save failed: "+e.message); }
-}
+
 async function loadSchedulesView(){
-  const data = await cfgGet("/api/config/schedules");
-  schedules = data || [];
-  // aggregate last execution per schedule id from scheduler-source logs
-  let lastExec = {};
+  schedules = await getJSON("/api/schedules/overview") || [];
+  renderScheduleCards();
+  renderSchedules();
+}
+
+function scheduleEntryForSave(e){
+  // V1 blacklist is enough because overview adds only these two computed fields.
+  // If ScheduleOverviewItem gains more computed fields later, switch this to an explicit whitelist.
+  const { nextFireAt, lastRun, ...entry } = e;
+  return entry;
+}
+
+async function persistSchedules(){
+  const payload = schedules.map(scheduleEntryForSave);
   try {
-    const logs = await cfgGet("/api/logs?source=scheduler&limit=500");
-    for(const l of (logs.logs||[])){
-      const m = (l.taskId||"").match(/^schedule:([^:]+):/);
-      if(!m) continue;
-      const id = m[1];
-      if(!lastExec[id] || l.startedAt > lastExec[id].startedAt) lastExec[id] = l;
-    }
-  } catch(_){}
-  renderSchedules(lastExec);
+    const r = await cfgWrite("/api/config/schedules", { schedules: payload });
+    if(r.error) return toast("Error: "+r.error);
+    toast("Saved; takes effect immediately");
+    await loadSchedulesView();
+  } catch(e){
+    toast("Save failed: "+e.message);
+  }
+}
+
+async function loadSchedStats(){
+  if(!schedHistory.id) return;
+  const s = await getJSON(`/api/schedules/${encodeURIComponent(schedHistory.id)}/stats`);
+  const success = s.byStatus.success || 0;
+  const failed = (s.byStatus.error || 0) + (s.byStatus["validation-failed"] || 0);
+  document.getElementById("sched-stats").innerHTML = [
+    ["Runs", s.totalRuns],
+    ["Success", success],
+    ["Failed", failed],
+    ["Avg duration", fmtDur(s.avgDurationMs)],
+    ["Output tokens", s.token.output],
+  ].map(([k,v])=>`<div class="card"><div class="k">${k}</div><div class="v">${v}</div></div>`).join("");
+}
+
+async function loadSchedHistory(){
+  if(!schedHistory.id) return;
+  const p = new URLSearchParams();
+  p.set("limit", schedHistory.limit);
+  p.set("offset", schedHistory.offset);
+  const data = await getJSON(`/api/schedules/${encodeURIComponent(schedHistory.id)}/runs?${p}`);
+  schedHistory.total = data.total;
+  const rows = data.logs.map(l=>{
+    return `<tr class="row" data-log="${esc(l.id)}">
+      <td>${fmtTime(l.startedAt)}</td>
+      <td>${statusBadge(l.status)}</td>
+      <td>${l.phase==="self-heal"?'<span class="badge b-auto-fixed">self-heal</span>':""}</td>
+      <td>${esc(l.project||"—")}</td>
+      <td>${fmtDur(l.durationMs)}</td>
+      <td>${l.usage.total}</td>
+      <td>${esc((l.replyText||"").slice(0,80))}</td>
+    </tr>`;
+  }).join("");
+  const bodyRows = data.logs.length ? rows : '<tr><td colspan="7" class="muted">No records</td></tr>';
+
+  document.getElementById("sched-history").style.display="block";
+  document.getElementById("sched-history").innerHTML = `
+    <div class="section-title">History: ${esc(schedHistory.id)}</div>
+    <div class="cards" id="sched-stats"></div>
+    <table>
+      <thead><tr><th>Time</th><th>Status</th><th>Phase</th><th>Project</th><th>Duration</th><th>Tokens</th><th>Reply</th></tr></thead>
+      <tbody>${bodyRows}</tbody>
+    </table>
+    <div class="pager">
+      <button class="ghost" id="sh-prev" ${schedHistory.offset<=0?"disabled":""}>← Prev</button>
+      <span class="muted">Page ${Math.floor(schedHistory.offset/schedHistory.limit)+1} · ${schedHistory.total} total</span>
+      <button class="ghost" id="sh-next" ${schedHistory.offset+schedHistory.limit>=schedHistory.total?"disabled":""}>Next →</button>
+    </div>`;
+
+  document.querySelectorAll("#sched-history tr.row").forEach(tr=>tr.onclick=()=>showDetail(tr.dataset.log));
+  document.getElementById("sh-prev").onclick=()=>{ schedHistory.offset=Math.max(0,schedHistory.offset-schedHistory.limit); loadSchedHistory(); };
+  document.getElementById("sh-next").onclick=()=>{
+    const nextOffset = schedHistory.offset + schedHistory.limit;
+    if(nextOffset >= schedHistory.total) return;
+    schedHistory.offset = nextOffset;
+    loadSchedHistory();
+  };
+  await loadSchedStats();
+}
+
+function openSchedHistory(id){
+  schedHistory = { id, offset:0, limit:20, total:0 };
+  loadSchedHistory();
 }
 
 function openSchedModal(id){
@@ -1009,11 +1110,10 @@ async function loadConfig(){
   document.getElementById("sp-text").value = c.systemPrompt || "";
   document.getElementById("sp-count").textContent = `${(c.systemPrompt||"").length} chars`;
   renderWechatStatus(c.wechat);
-  await loadSchedulesView();
   await loadBackups();
 }
 
-// ---- wire config buttons ----
+// ---- wire schedules buttons ----
 document.getElementById("sched-add").onclick = ()=>openSchedModal(null);
 document.getElementById("sched-reload").onclick = async ()=>{ await loadSchedulesView(); toast("Refreshed"); };
 

--- a/src/webui/index.html
+++ b/src/webui/index.html
@@ -868,9 +868,7 @@ async function persistSchedules(){
   }
 }
 
-async function loadSchedStats(){
-  if(!schedHistory.id) return;
-  const s = await getJSON(`/api/schedules/${encodeURIComponent(schedHistory.id)}/stats`);
+function renderSchedStats(s){
   const success = s.byStatus.success || 0;
   const failed = (s.byStatus.error || 0) + (s.byStatus["validation-failed"] || 0);
   document.getElementById("sched-stats").innerHTML = [
@@ -887,7 +885,10 @@ async function loadSchedHistory(){
   const p = new URLSearchParams();
   p.set("limit", schedHistory.limit);
   p.set("offset", schedHistory.offset);
-  const data = await getJSON(`/api/schedules/${encodeURIComponent(schedHistory.id)}/runs?${p}`);
+  const [data, s] = await Promise.all([
+    getJSON(`/api/schedules/${encodeURIComponent(schedHistory.id)}/runs?${p}`),
+    getJSON(`/api/schedules/${encodeURIComponent(schedHistory.id)}/stats`),
+  ]);
   schedHistory.total = data.total;
   const rows = data.logs.map(l=>{
     return `<tr class="row" data-log="${esc(l.id)}">
@@ -904,7 +905,10 @@ async function loadSchedHistory(){
 
   document.getElementById("sched-history").style.display="block";
   document.getElementById("sched-history").innerHTML = `
-    <div class="section-title">History: ${esc(schedHistory.id)}</div>
+    <div class="section-title" style="display:flex;justify-content:space-between;align-items:center">
+      <span>History: ${esc(schedHistory.id)}</span>
+      <button class="btn ghost" id="sched-history-close">Close</button>
+    </div>
     <div class="cards" id="sched-stats"></div>
     <table>
       <thead><tr><th>Time</th><th>Status</th><th>Phase</th><th>Project</th><th>Duration</th><th>Tokens</th><th>Reply</th></tr></thead>
@@ -917,6 +921,10 @@ async function loadSchedHistory(){
     </div>`;
 
   document.querySelectorAll("#sched-history tr.row").forEach(tr=>tr.onclick=()=>showDetail(tr.dataset.log));
+  document.getElementById("sched-history-close").onclick = ()=>{
+    document.getElementById("sched-history").style.display="none";
+    schedHistory = { id:null, offset:0, limit:20, total:0 };
+  };
   document.getElementById("sh-prev").onclick=()=>{ schedHistory.offset=Math.max(0,schedHistory.offset-schedHistory.limit); loadSchedHistory(); };
   document.getElementById("sh-next").onclick=()=>{
     const nextOffset = schedHistory.offset + schedHistory.limit;
@@ -924,7 +932,7 @@ async function loadSchedHistory(){
     schedHistory.offset = nextOffset;
     loadSchedHistory();
   };
-  await loadSchedStats();
+  renderSchedStats(s);
 }
 
 function openSchedHistory(id){

--- a/src/webui/server.ts
+++ b/src/webui/server.ts
@@ -32,6 +32,7 @@ import {
 import { loadSchedules, saveSchedules } from "../scheduler/store.ts";
 import { reloadSchedules } from "../scheduler/engine.ts";
 import { nextFireEpoch } from "../scheduler/cron.ts";
+import { scheduleOverview, scheduleRuns, scheduleRunStats } from "../scheduler/history.ts";
 import { loadAccount, resolveAccount } from "../channels/wechat/account.ts";
 import { getContext } from "../channels/wechat/context.ts";
 import { reminderStatus } from "../channels/wechat/reminder.ts";
@@ -196,6 +197,17 @@ export function startWebui(): void {
 				if (!requireUiHeader(req, res)) return;
 				const body = (await readJsonBody(req)) as CleanupOptions;
 				return json(res, cleanupLogs(body));
+			}
+
+			const schedRunsMatch = path.match(/^\/api\/schedules\/([^/]+)\/runs$/);
+			const schedStatsMatch = path.match(/^\/api\/schedules\/([^/]+)\/stats$/);
+
+			if (path === "/api/schedules/overview") return json(res, scheduleOverview());
+			if (schedRunsMatch) {
+				return json(res, scheduleRuns(decodeURIComponent(schedRunsMatch[1]), parseQuery(url)));
+			}
+			if (schedStatsMatch) {
+				return json(res, scheduleRunStats(decodeURIComponent(schedStatsMatch[1])));
 			}
 
 			// ---- Config endpoints (WebUI) ----


### PR DESCRIPTION
## Summary

Applies the scheduler WebUI history review feedback:

- Make `ScheduleOverviewItem` transparently extend `ScheduleEntry` so new schedule fields propagate automatically.
- Refactor `scheduleOverview()` to use object spread.
- Extract testable `aggregateRunStats()` and `scheduleOverviewFromLogs()` helpers.
- Add scheduler history unit tests for stats aggregation and overview latest-run selection.
- Add a Close button to the scheduler history view.
- Load schedule runs and stats in parallel instead of sequentially.

## Verification

- `npm run typecheck`
- `npm test` (124 passing)
- WebUI inline script syntax check
- `git diff --check`
- WebUI endpoint smoke tests for schedule overview, runs, and stats