### PR TITLE
fix: harden conversation context handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,8 @@ DATA_ROOT=/path/to/your/data-root
 TELEGRAM_BOT_TOKEN=
 # On the mainland China network the Telegram API is blocked, so a proxy is required to connect; fill in your proxy (e.g. Clash default http://127.0.0.1:7890)
 TG_PROXY=
+# Optional comma-separated Telegram sender allowlist (user ids or usernames). Empty = allow all.
+TELEGRAM_ALLOW_FROM=
 
 # ===== Channel: Feishu (event subscription webhook) =====
 # Left empty to disable Feishu
@@ -31,6 +33,8 @@ FEISHU_VERIFICATION_TOKEN=
 FEISHU_ENCRYPT_KEY=
 # Feishu webhook listening port
 FEISHU_PORT=3000
+# Optional comma-separated Feishu allowlist (sender open_id/user_id/union_id or chat_id). Empty = allow all.
+FEISHU_ALLOW_FROM=
 
 # ===== Channel: WeChat (iLink / ClawBot official Bot API, text-only DMs) =====
 # Set to 1 to enable the WeChat channel. Log in first via: npm start -- wechat-login
@@ -96,3 +100,5 @@ SCHEDULER_ENABLED=0
 # CONVERSATION_CONTEXT_TURNS=5
 # Max characters kept for each user or assistant message (not a whole-window cap). Default 4000.
 # CONVERSATION_TURN_MAX_CHARS=4000
+# Whole-window character cap for injected conversation context; oldest turns are dropped first. Default 12000.
+# CONVERSATION_CONTEXT_MAX_CHARS=12000

--- a/.env.example
+++ b/.env.example
@@ -86,3 +86,13 @@ SCHEDULER_ENABLED=0
 # Max tool-call turns allowed per task (one assistant message with >=1 toolCall counts as 1 turn).
 # As the limit is approached the framework hints the model to wrap up; at the limit it hard-stops. Default 20.
 # MAX_TOOL_TURNS=20
+
+# ===== Conversation context (recent visible turns) =====
+# Recent user + Bot turns are injected into routing/execution for short follow-ups such as
+# "confirmed" or "change it to 8 o'clock". Shared across Telegram / Feishu / WeChat as one "im"
+# session; scheduler and CLI messages do not use it. Disable by setting the first value to 0.
+# CONVERSATION_CONTEXT_ENABLED=1
+# Number of recent turns kept (0 disables injection). Default 5.
+# CONVERSATION_CONTEXT_TURNS=5
+# Max characters kept for each user or assistant message (not a whole-window cap). Default 4000.
+# CONVERSATION_TURN_MAX_CHARS=4000

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This file is for AI coding assistants (and any contributors) working in this rep
 Key design principles (understand before changing, do not break):
 
 1. **The framework only defines boundaries, it does not hardcode business logic**: the operable directories (first-level subdirs of `DATA_ROOT`), the toolset (read/write/edit/run + schedule, where run is limited to existing in-project scripts and schedule only writes the fixed externalized `schedules.json`, neither is an arbitrary shell), the post-write JSON-validity fallback, and automatic git commit. Business schemas and rules are self-described by each data subproject's root `AGENTS.md`, concatenated into the system prompt at runtime.
-2. **Each message = a brand-new `Agent` instance**, with no cross-task memory. Therefore any "retry/fix" must be a **self-contained instruction** (pointing to the file + location + how to change it), not relying on the previous conversation.
+2. **Each message = a brand-new `Agent` instance**, but IM channels inject the most recent user-visible conversation turns as prompt context. The agent still has no internal tool-call / thinking memory, so any "retry/fix" must be a **self-contained instruction** (pointing to the file + location + how to change it), not relying on the previous conversation.
 3. **App / data separation**: this repo (including `.env`) and the `DATA_ROOT` data directory are two separate locations. The data directory contains only the projects being operated on — no source code or secrets.
 4. **Config externalized**: the system prompt, the real `.env`, and `providers.json` (custom model providers) live in `~/.botler-agent/` (overridable via `BOTLER_CONFIG_DIR`), reused across clones / machines. The source-dir `.env` is only a dev fallback.
 5. **Path allowlist is a security boundary**: the agent's tools may only read/write first-level subdirs of `DATA_ROOT`. Do not relax `safePath`, do not add `bash`-class tools to the agent unless explicitly requested and the consequences are understood.
@@ -39,11 +39,12 @@ npm test               # node:test suite (scheduler cron + store)
 
 ```
 channel (telegram.ts / feishu.ts)
-   → dispatcher.ts  dispatch(text, {id, source})
+   → dispatcher.ts  dispatch(text, {id, source, sessionKey: "im"})
        ├─ dedup (5-minute window, by id)
        ├─ sequential queue (Promise chain, serializes writes)
        └─ runner.ts  runTask(text)
              ├─ resolveModel() (provider/model resolution + cache)
+             ├─ loadRecentTurns() (shared IM recent visible turns; scheduler / CLI skip)
              ├─ loadSystemPrompt() (externalized first, fallback to built-in default; injects __DATA_ROOT__ / __PROJECTS__)
              ├─ new Agent({ systemPrompt, model, tools: fileTools })
              ├─ agent.prompt(text)
@@ -65,6 +66,7 @@ scheduler (scheduler/engine.ts) → dispatch(schedule.message, {id, source:"sche
 | `src/init.ts` | Initialize `~/.botler-agent/` (.env + providers.json + system-prompt.md templates); existing files not overwritten |
 | `src/config.ts` | Two-level `.env` loading (user-level > source-level) + providers.json loading + `CONFIG` construction + `USER_CONFIG_DIR` |
 | `src/dispatcher.ts` | Dedup, sequential queue, validation retry, commit orchestration (**never rejects**) |
+| `src/conversation/store.ts` | Shared `im` session sliding-window store (`~/.botler-agent/conversations/im.json`) + prompt formatting; scheduler / CLI / self-heal do not read or write it |
 | `src/runner.ts` | Build Agent, run task, extract final reply, decide whether it mutated; greeting short-circuit (`greeting.ts`) + image-aware routing |
 | `src/providers.ts` | Build a custom provider config into a pi-ai `Provider` (openai-completions) |
 | `src/prompts/system-prompt.ts` | Built-in generic default prompt + `loadSystemPrompt()` (externalized first + placeholder injection) |
@@ -106,7 +108,7 @@ The allowlist = first-level (non-hidden) subdirs of `DATA_ROOT`, computed dynami
 
 The framework **does not validate business semantics** (field values, aggregation consistency, etc.) — it only checks "all data JSON is valid JSON". This is the last line of defense against `edit` text replacement breaking JSON syntax (the `write` tool itself guarantees validity). Business rules are guaranteed by each subproject's `AGENTS.md` conventions + the project's own scripts.
 
-Each `runTask` is a brand-new Agent with no memory. On validation failure, the `fix` must be a **self-contained** correction instruction ("read file X, fix the JSON syntax, do not create a new file"). The dispatcher retries at most once; if still failing, it returns an error and does not commit.
+Each `runTask` is a brand-new Agent with no internal tool/thinking memory (recent visible turns may be injected as prompt text). On validation failure, the `fix` must be a **self-contained** correction instruction ("read file X, fix the JSON syntax, do not create a new file"). The dispatcher retries at most once; if still failing, it returns an error and does not commit.
 
 ### 4. Commit strategy (`safety/git.ts`)
 

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -17,7 +17,7 @@
 刻意做**轻**，区别于重型 Agent 框架：
 
 - **轻量** — 只有五个工具，无重型运行时 / 守护进程，一个 `tsx` 进程即可，秒级安装。
-- **省 token** — 每个任务都是全新短命 Agent，无跨任务记忆；路由只用「项目名 + 摘要」小提示词，只加载被选中子项目的约定。没有巨型 system prompt、不追长上下文，多数任务成本只有通用助手的零头。
+- **省 token** — 每个任务都是全新短命 Agent，仅复用受限的最近可见对话窗口；路由只用「项目名 + 摘要」小提示词，只加载被选中子项目的约定。没有巨型 system prompt、不追长上下文，多数任务成本只有通用助手的零头。
 - **聚焦垂直简单任务** — 不是通用聊天机器人，擅长小、重复、边界清晰的活（饮食记录、生词查询、定时提醒），每个由自己的 `AGENTS.md` 描述。
 
 ## botler-agent 与同类对比
@@ -239,8 +239,8 @@ Scheduler ──► dispatch(schedule.message) ──►（同上流水线）
 
 ## 渠道
 
-- **Telegram**（`grammy`，长轮询）：最简单，首选。需要 `TELEGRAM_BOT_TOKEN`；大陆网络下需配置 `TG_PROXY` 才能连接 API。
-- **飞书**（事件订阅 webhook，含解密）：需要 `FEISHU_APP_ID` / `FEISHU_APP_SECRET`；可选 `FEISHU_VERIFICATION_TOKEN` / `FEISHU_ENCRYPT_KEY`，监听 `FEISHU_PORT`（默认 3000）。
+- **Telegram**（`grammy`，长轮询）：最简单，首选。需要 `TELEGRAM_BOT_TOKEN`；大陆网络下需配置 `TG_PROXY` 才能连接 API。可设置 `TELEGRAM_ALLOW_FROM`（逗号分隔的 Telegram 用户 id 或用户名）限制发送者；留空则全部放行。
+- **飞书**（事件订阅 webhook，含解密）：需要 `FEISHU_APP_ID` / `FEISHU_APP_SECRET`；可选 `FEISHU_VERIFICATION_TOKEN` / `FEISHU_ENCRYPT_KEY`，监听 `FEISHU_PORT`（默认 3000）。可设置 `FEISHU_ALLOW_FROM`（逗号分隔的发送者 `open_id`/`user_id`/`union_id` 或 chat id）限制发送者；留空则全部放行。
 - **微信（iLink / ClawBot 官方 Bot API）**：私聊渠道。先用 `npm start -- wechat-login` 登录（终端打印二维码，用微信扫码——凭据存入 `~/.botler-agent/wechat/account.json`），再设 `WECHAT_ENABLED=1` 启用。账号主号（扫码者）始终允许；`WECHAT_ALLOW_FROM` 可额外放行 `ilink_user_id`。续期提醒（`WECHAT_REMINDER_HOURS`）会在主号 24h `context_token` 窗口临近过期前提醒其刷新。
   - **入站图片即视觉输入**：微信可接收你发来的图片，解码后作为视觉输入喂给模型，并把原图持久化到 `DATA_ROOT/<project>/photos/`。由于微信「选图即发、文字后到」，入站图片会在一个短暂窗口内暂存（`WECHAT_IMAGE_BATCH_SECONDS`，默认 60s；设 `0` 关闭），让随后补发的文字作为同一条任务的描述合并进入；窗口内的多张图片也会合并。若当前模型无法读图，代理会用中文回复，请你补一句文字说明。
   - **问候短路**：仅含问候（如 你好 / hi）的消息会跳过路由 LLM 调用，直接给出一份零开销的中文欢迎语，列出当前可用子项目。
@@ -358,10 +358,12 @@ src/
 | `~/.botler-agent/providers.json` | 自定义 OpenAI-completions / Anthropic-messages 网关（每个 provider 含 baseUrl / apiKey / models）；旧版兜底：`CUSTOM_BASE_URL` / `CUSTOM_API_KEY` 环境变量 |
 | `TELEGRAM_BOT_TOKEN` | Telegram BotFather token；留空则不启动 Telegram |
 | `TG_PROXY` | 大陆网络下 Telegram API 需要代理（如 `http://127.0.0.1:7890`） |
+| `TELEGRAM_ALLOW_FROM` | 可选逗号分隔的 Telegram 发送者白名单（用户 id 或用户名）；留空则全部放行 |
 | `FEISHU_APP_ID` / `FEISHU_APP_SECRET` | 飞书应用凭据；留空则不启动飞书 |
 | `FEISHU_VERIFICATION_TOKEN` | 飞书事件订阅 URL 校验 token（可选） |
 | `FEISHU_ENCRYPT_KEY` | 飞书消息加密 key；不填则只处理明文事件 |
 | `FEISHU_PORT` | 飞书 webhook 监听端口，默认 `3000` |
+| `FEISHU_ALLOW_FROM` | 可选逗号分隔的飞书发送者白名单（`open_id`/`user_id`/`union_id` 或 chat id）；留空则全部放行 |
 | `WECHAT_ENABLED` | `=1` 启动微信 iLink 渠道（需先完成 `wechat-login`） |
 | `WECHAT_ALLOW_FROM` | 可选逗号分隔的额外 `ilink_user_id` 白名单（主号始终允许） |
 | `WECHAT_REMINDER_HOURS` | 微信续期提醒阈值：`0`=关闭，`1`-`24`=主号静默 N 小时后提醒（默认 23） |
@@ -377,6 +379,10 @@ src/
 | `BOTLER_HOLIDAY_API_URL` | `holidayMode:"workday"` 用的中国法定节假日日历源；`{year}` 占位符会被替换（默认 `https://raw.githubusercontent.com/NateScarlet/holiday-cn/master/{year}.json`） |
 | `BOTLER_HOLIDAYS_FILE` | 缓存的节假日日历文件（默认 `~/.botler-agent/holidays.json`） |
 | `MAX_TOOL_TURNS` | 单任务最大工具轮次（默认 20；临近上限时提示收尾，达到上限强制停止） |
+| `CONVERSATION_CONTEXT_ENABLED` | `=0` 关闭最近对话上下文注入（默认开启） |
+| `CONVERSATION_CONTEXT_TURNS` | 每个 IM 会话保留的最近可见轮数（默认 5；`0` 关闭注入） |
+| `CONVERSATION_TURN_MAX_CHARS` | 每条存储的用户/助手消息最大字符数（默认 4000） |
+| `CONVERSATION_CONTEXT_MAX_CHARS` | 注入上下文的全窗口字符上限；超限时从最旧轮开始丢弃（默认 12000） |
 
 ## 工作原理
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A general-purpose, lightweight personal agent framework: it receives messages fr
 A deliberately **lightweight** alternative to heavyweight agent frameworks:
 
 - **Lightweight** — only five tools, no heavy runtime or daemon; a single `tsx` process, installed in seconds.
-- **Token-thrifty** — every task is a fresh, short-lived Agent with no cross-task memory; routing uses only a tiny project-name + summary prompt, and only the selected subproject's conventions are loaded. No giant system prompts, no chasing long contexts — most tasks cost a fraction of a general-assistant call.
+- **Token-thrifty** — every task is a fresh, short-lived Agent; only a bounded recent-visible-conversation window is reused across IM turns. Routing uses a tiny project-name + summary prompt, and only the selected subproject's conventions are loaded. No giant system prompts, no chasing long contexts — most tasks cost a fraction of a general-assistant call.
 - **Focused on simple vertical tasks** — not a general-purpose chatbot. It shines at small, repetitive, well-scoped jobs (meal logging, vocabulary lookups, reminders), each described by its own `AGENTS.md`.
 
 ## How botler-agent compares
@@ -220,8 +220,8 @@ Once the system prompt is externalized, you (or the AI assistant) can customize 
 
 ## Channels
 
-- **Telegram** (`grammy`, long polling): simplest, preferred. Requires `TELEGRAM_BOT_TOKEN`; on the mainland China network a `TG_PROXY` is required to connect to the API.
-- **Feishu** (event-subscription webhook with decryption): requires `FEISHU_APP_ID` / `FEISHU_APP_SECRET`; optional `FEISHU_VERIFICATION_TOKEN` / `FEISHU_ENCRYPT_KEY`, listens on `FEISHU_PORT` (default 3000).
+- **Telegram** (`grammy`, long polling): simplest, preferred. Requires `TELEGRAM_BOT_TOKEN`; on the mainland China network a `TG_PROXY` is required to connect to the API. Set `TELEGRAM_ALLOW_FROM` (comma-separated Telegram user ids or usernames) to restrict senders; leave empty to allow all.
+- **Feishu** (event-subscription webhook with decryption): requires `FEISHU_APP_ID` / `FEISHU_APP_SECRET`; optional `FEISHU_VERIFICATION_TOKEN` / `FEISHU_ENCRYPT_KEY`, listens on `FEISHU_PORT` (default 3000). Set `FEISHU_ALLOW_FROM` (comma-separated sender `open_id`/`user_id`/`union_id` or chat ids) to restrict senders; leave empty to allow all.
 - **WeChat (iLink / ClawBot official Bot API)**: DM channel. Enable with `WECHAT_ENABLED=1` after logging in via `npm start -- wechat-login` (prints a QR code in the terminal; scan it with WeChat — credentials saved to `~/.botler-agent/wechat/account.json`). The account owner (the QR scanner) is always allowed; `WECHAT_ALLOW_FROM` can allowlist extra `ilink_user_id`s. A renewal reminder (`WECHAT_REMINDER_HOURS`) nudges the owner to refresh the 24h `context_token` window.
   - **Inbound images as vision input**: WeChat can receive images you send. They are decoded and fed to the model as vision input, and the originals are persisted under `DATA_ROOT/<project>/photos/`. Because WeChat delivers a selected photo immediately while you may still be typing the caption ("选图即发，文字后到"), inbound image messages are held for a short window (`WECHAT_IMAGE_BATCH_SECONDS`, default 60s; `0` disables) so a following text joins the batch as one task; multiple photos in the window also merge. If the configured model cannot read images, the agent replies in Chinese asking you to add a short text hint.
   - **Greeting short-circuit**: a bare greeting (e.g. 你好 / hi) skips the routing LLM call entirely and gets a deterministic Chinese welcome that lists the available subprojects — zero model cost.
@@ -306,10 +306,12 @@ By default a local health/metrics server runs on `127.0.0.1:MONITOR_PORT` (defau
 | `~/.botler-agent/providers.json` | Custom OpenAI-completions / Anthropic-messages gateways (baseUrl / apiKey / models per provider); legacy fallback: `CUSTOM_BASE_URL` / `CUSTOM_API_KEY` env vars |
 | `TELEGRAM_BOT_TOKEN` | Telegram BotFather token; left empty to disable Telegram |
 | `TG_PROXY` | Telegram API needs a proxy on the mainland China network (e.g. `http://127.0.0.1:7890`) |
+| `TELEGRAM_ALLOW_FROM` | Optional comma-separated Telegram sender allowlist (user ids or usernames); empty = allow all |
 | `FEISHU_APP_ID` / `FEISHU_APP_SECRET` | Feishu app credentials; left empty to disable Feishu |
 | `FEISHU_VERIFICATION_TOKEN` | Feishu event subscription URL verification token (optional) |
 | `FEISHU_ENCRYPT_KEY` | Feishu message encryption key; if empty, only plaintext events are processed |
 | `FEISHU_PORT` | Feishu webhook listening port, default `3000` |
+| `FEISHU_ALLOW_FROM` | Optional comma-separated Feishu sender allowlist (`open_id`/`user_id`/`union_id` or chat id); empty = allow all |
 | `WECHAT_ENABLED` | `=1` to start the WeChat iLink channel (requires a completed `wechat-login`) |
 | `WECHAT_ALLOW_FROM` | Optional comma-separated extra `ilink_user_id` allowlist (owner always allowed) |
 | `WECHAT_REMINDER_HOURS` | WeChat renewal reminder threshold: `0`=off, `1`-`24`=remind owner after N hours (default 23) |
@@ -325,6 +327,10 @@ By default a local health/metrics server runs on `127.0.0.1:MONITOR_PORT` (defau
 | `BOTLER_HOLIDAY_API_URL` | China legal-holiday calendar source for `holidayMode:"workday"`; the `{year}` placeholder is substituted (default `https://raw.githubusercontent.com/NateScarlet/holiday-cn/master/{year}.json`) |
 | `BOTLER_HOLIDAYS_FILE` | Cached holiday calendar file (default `~/.botler-agent/holidays.json`) |
 | `MAX_TOOL_TURNS` | Max tool-call turns per task (default 20; the model is hinted to wrap up as the limit approaches, then hard-stopped) |
+| `CONVERSATION_CONTEXT_ENABLED` | `=0` disables recent-conversation injection (default enabled) |
+| `CONVERSATION_CONTEXT_TURNS` | Number of recent visible turns kept per IM session (default 5; `0` disables injection) |
+| `CONVERSATION_TURN_MAX_CHARS` | Max characters kept per stored user/assistant message (default 4000) |
+| `CONVERSATION_CONTEXT_MAX_CHARS` | Whole-window character cap for injected context; oldest turns are dropped first (default 12000) |
 
 ## How it works
 

--- a/docs/ds-conversation-context.md
+++ b/docs/ds-conversation-context.md
@@ -127,8 +127,7 @@ im
       "ts": 1787793138548,
       "project": "cook",
       "user": "确认写入午餐记录",
-      "assistant": "已写入今天午餐记录：600 卡路里。",
-      "imageRefs": []
+      "assistant": "已写入今天午餐记录：600 卡路里。"
     }
   ]
 }
@@ -140,9 +139,10 @@ im
 - `project`：执行阶段最终路由到的项目名；如果本轮未识别出项目但产生了最终回复，则为 `null`。
 - `user`：用户本轮输入文本。
 - `assistant`：Bot 本轮最终回复文本。
-- `imageRefs`：历史图片引用路径（通常为项目内相对路径）。不保存 base64，也不生成图片摘要；后续如需继续使用该图片，由用户再次要求 Botler 识别。
 
-每个 `user` 和 `assistant` 字段都做字符上限截断，防止单轮超长回复占据整个窗口。
+每个 `user` 和 `assistant` 字段都做单条字符上限截断；注入模型时，整个最近对话块还受
+`CONVERSATION_CONTEXT_MAX_CHARS` 总量上限约束，超限时从最旧轮开始丢弃。历史不保存
+base64、图片摘要或图片引用路径；后续如需继续使用某张图片，由用户再次要求 Botler 识别。
 
 ### 4.3 写入与权限
 
@@ -235,7 +235,6 @@ export interface ConversationTurn {
   project: string | null;
   user: string;
   assistant: string;
-  imageRefs: string[];
 }
 
 export function loadRecentTurns(
@@ -258,7 +257,6 @@ export function clearSession(sessionKey: string): void;
 
 ```ts
 sessionKey?: string;
-recentTurns?: ConversationTurn[];
 ```
 
 ### 6.3 渠道传递会话信息
@@ -284,6 +282,7 @@ Scheduler 和 CLI 不传。
 CONVERSATION_CONTEXT_ENABLED=1
 CONVERSATION_CONTEXT_TURNS=5
 CONVERSATION_TURN_MAX_CHARS=4000
+CONVERSATION_CONTEXT_MAX_CHARS=12000
 ```
 
 默认值：
@@ -292,9 +291,13 @@ CONVERSATION_TURN_MAX_CHARS=4000
 enabled = true
 maxTurns = 5
 maxCharsPerMessage = 4000
+maxCharsPerContext = 12000
 ```
 
 `CONVERSATION_TURN_MAX_CHARS` 是单条 `user` 或 `assistant` 消息上限，不是 N 轮总上限；先保持 4000，如果后续观察到正常回复被截断，再调高。
+
+`CONVERSATION_CONTEXT_MAX_CHARS` 是注入上下文的总字符上限；当最近 N 轮超过该值时，从
+最旧一轮开始丢弃，避免叠加项目约定文档后挤爆长系统提示词。
 
 不新增 TTL 配置。
 
@@ -307,6 +310,7 @@ maxCharsPerMessage = 4000
 | 模型误判 | 用户纠正，纠正消息进入上下文，后续可修正 |
 | 历史超过 N 轮 | 最旧一轮滚动丢弃 |
 | 昨天问、今天确认 | 没有 TTL，仍可继续 |
+| greeting / 无数据子项目短路回复 | 不写入历史 |
 | Scheduler 消息 | 不加载用户聊天上下文 |
 | Self-heal | 不读取、不写入聊天上下文 |
 | CLI 调试 | 默认不启用上下文 |
@@ -319,10 +323,12 @@ maxCharsPerMessage = 4000
 - 最近 N 轮加载顺序。
 - 超过 N 轮后旧轮淘汰。
 - 单条消息字符截断。
+- 最近对话总量超过 `CONVERSATION_CONTEXT_MAX_CHARS` 时从最旧轮开始丢弃。
 - `phase === "self-heal"` 不读取、不写入。
 - `duplicate`、`validation-failed`、`error` 不写入。
 - `unknown-project` 且存在最终 assistant 回复时写入，`project` 为 `null`。
 - Scheduler/CLI 不加载历史。
+- greeting / 无数据子项目短路回复不写入历史。
 - 历史路由提示能包含旧任务信息。
 - 多项目历史下，“确认”能路由到最近一个有 `project` 的轮。
 - 上下文注入后的 token 增长不会导致长系统提示词被截断；必要时截断历史或降低 N。

--- a/docs/ds-conversation-context.md
+++ b/docs/ds-conversation-context.md
@@ -1,0 +1,336 @@
+# Botler 对话上下文方案：最近 N 轮滚动窗口
+
+> 状态：已实现
+> 原则：只保留最近 N 轮用户可见对话，不引入 TTL、摘要压缩、RAG 或长期记忆。上下文边界交给 LLM 判断。
+
+## 1. 背景与问题
+
+当前 Botler 每条消息都创建一个全新的 `Agent`，`initialState.messages` 为空，系统提示词也明确写着：
+
+> 每条消息都是一次独立任务，没有跨任务记忆。
+
+这导致 LLM 反问用户、等待二次确认、或需要用户补充信息时，用户不能只回复：
+
+```text
+好的
+确认
+改成 8 点
+继续
+刚才那条不对，改成 X
+```
+
+因为新的 Agent 不知道上一轮在做什么，用户必须重新复述完整上下文。
+
+本方案只解决同一个会话内的短程连续交互，不追求 CodeBuddy/OpenCode 那样的完整上下文管理。
+
+## 2. 核心设计
+
+### 2.1 上下文单位：轮
+
+一轮对话定义为一次用户可见的完整交换：
+
+```text
+用户消息 -> Agent 执行 -> Bot 最终回复
+```
+
+历史只保存这层可见内容，不保存 Agent 内部的 `thinking`、`toolCall`、`toolResult`。这些内部信息继续由 `task-logs` 记录，用于审计和排障，但不作为下一轮上下文。
+
+### 2.2 滑动窗口
+
+每个会话只保留最近 `N` 轮：
+
+```text
+最近第 N 轮
+最近第 N-1 轮
+...
+最近第 1 轮
+```
+
+超过 `N` 轮后，最旧的一轮自然丢弃。窗口大小按“轮”而不是“消息条数”计算，避免拆散同一轮中的用户消息和 Bot 回复。
+
+### 2.3 不设 TTL
+
+不按时间过期上下文。允许用户昨天没有回复确认，今天再回复“确认”，Bot 仍能理解前文。
+
+是否继续旧任务由 LLM 根据当前消息和历史共同判断：
+
+```text
+昨天：
+Bot：是否确认写入昨天的午餐记录？
+
+今天：
+用户：确认
+```
+
+LLM 应判断为继续旧任务。
+
+```text
+昨天：
+Bot：是否确认写入昨天的午餐记录？
+
+今天：
+用户：帮我记一下今天的早餐
+```
+
+LLM 应判断为新任务，按新任务处理。
+
+如果判断错了，用户继续纠正即可；纠正内容也会进入最近 N 轮上下文，后续可以重新做对。
+
+### 2.4 不引入复杂状态
+
+不增加：
+
+- 自动摘要。
+- 上下文压缩。
+- 上下文恢复。
+- pending-confirmation 状态机。
+- TTL。
+- RAG 长期记忆。
+
+框架只负责“读取最近历史、注入模型、写回本轮”。
+
+## 3. 会话标识
+
+Botler 面向个人使用，所有 IM 渠道共享同一个会话上下文，不再按渠道或用户拆分：
+
+```text
+im
+```
+
+规则：
+
+- Telegram、Feishu、WeChat 的用户消息统一使用固定 key `im`。
+- 共享上下文的假设是单用户、单使用人；跨渠道切换设备或入口时仍能延续最近对话。
+- 如果未来需要多用户隔离，再把 key 拆回渠道和用户维度。
+- Scheduler 触发的任务不继承用户聊天上下文。
+- CLI 调试消息默认不启用会话上下文。
+- Self-heal 内部修复不写入会话历史。
+
+## 4. 存储设计
+
+### 4.1 位置
+
+存放在用户配置目录，不进入 `DATA_ROOT`：
+
+```text
+~/.botler-agent/conversations/im.json
+```
+
+固定文件名，不存在 `userId` 路径注入问题。
+
+### 4.2 数据结构
+
+```json
+{
+  "turns": [
+    {
+      "ts": 1787793138548,
+      "project": "cook",
+      "user": "确认写入午餐记录",
+      "assistant": "已写入今天午餐记录：600 卡路里。",
+      "imageRefs": []
+    }
+  ]
+}
+```
+
+字段说明：
+
+- `ts`：本轮开始时间。
+- `project`：执行阶段最终路由到的项目名；如果本轮未识别出项目但产生了最终回复，则为 `null`。
+- `user`：用户本轮输入文本。
+- `assistant`：Bot 本轮最终回复文本。
+- `imageRefs`：历史图片引用路径（通常为项目内相对路径）。不保存 base64，也不生成图片摘要；后续如需继续使用该图片，由用户再次要求 Botler 识别。
+
+每个 `user` 和 `assistant` 字段都做字符上限截断，防止单轮超长回复占据整个窗口。
+
+### 4.3 写入与权限
+
+- 写入采用原子替换或临时文件加 rename。
+- 文件权限设为 `0600`。
+- 当前全局 dispatch 队列已经串行化任务，因此单会话写入天然不会并发交错。
+
+## 5. 运行时流程
+
+```text
+incoming message
+  -> use fixed session key "im"
+  -> load recent N turns
+  -> greeting short-circuit
+  -> routing with recent context
+  -> execution with recent context
+  -> final reply
+  -> append this visible turn
+```
+
+### 5.1 路由阶段
+
+路由阶段也加载最近 N 轮可见对话。
+
+`buildRoutePrompt()` 增加一个可选的历史上下文块：
+
+```text
+最近对话：
+用户：是否确认写入昨天的午餐记录？
+Bot：请确认是否写入今天午餐记录。
+```
+
+路由模型需要同时看到历史，才能把当前消息“确认”路由到上一个任务所属的项目。
+
+历史轮的 `project` 可能为 `null`，路由模型仍可通过其中的 `user` / `assistant` 内容判断上下文；如果仍无法确定，则输出 `UNKNOWN`。
+
+路由提示需要明确允许模型区分新旧任务：
+
+```text
+如果当前消息是上一轮任务的简短确认或补充，优先沿用最近对话对应的项目；
+如果当前消息明显是一个新的独立任务，忽略旧历史并按新任务判断；
+无法确定时输出 UNKNOWN。
+```
+
+### 5.2 执行阶段
+
+执行阶段把最近 N 轮可见对话作为上下文注入。
+
+推荐通过系统提示词增加上下文块，而不是把完整 `AgentMessage[]` 重新构造回 `initialState.messages`：
+
+```ts
+const historyBlock = formatRecentTurns(recentTurns);
+const systemPrompt = `${loadSystemPrompt(project)}\n\n${historyBlock}`;
+```
+
+这样可以避免恢复历史 assistant 消息时携带内部工具调用和 usage 元数据，实现更简单。
+
+系统提示词需要从“没有跨任务记忆”改为：
+
+```text
+你拥有最近若干轮用户可见对话作为上下文。当前消息如果明显是新的独立任务，请忽略旧历史并按新任务处理；如果它是上一轮任务的确认、补充或纠正，请结合历史继续处理。无法确定时向用户确认。
+```
+
+### 5.3 写回时机
+
+只要本轮正常执行并产生了最终 assistant 回复，就写入 `user` + `assistant`；`project` 可以为 `null`。
+
+写回条件：
+
+- `phase === "execute"`
+- 存在最终 assistant 回复文本
+- `project` 可为 `null`
+- `TaskStatus` 属于 `success` / `auto-fixed` / `unknown-project`
+- 不写入 `duplicate` / `validation-failed` / `error`
+- `self-heal` 不读取、不写入
+
+当前代码中的 `phase` 枚举只有 `execute | self-heal`；`aborted` / `timeout` 属于 `stopReason` 或工具轮次上限，不是 `phase`。这些没有最终 assistant 回复的情况由“存在最终 assistant 回复”条件排除。
+
+查询任务虽然没有修改文件，但用户和 Bot 的问答仍然是有意义的上下文，因此也写入。
+
+## 6. 代码改造点
+
+### 6.1 新增会话存储模块
+
+新增 `src/conversation/store.ts`：
+
+```ts
+export interface ConversationTurn {
+  ts: number;
+  project: string | null;
+  user: string;
+  assistant: string;
+  imageRefs: string[];
+}
+
+export function loadRecentTurns(
+  sessionKey: string,
+  maxTurns: number,
+): ConversationTurn[];
+
+export function appendTurn(
+  sessionKey: string,
+  turn: ConversationTurn,
+  maxTurns: number,
+): void;
+
+export function clearSession(sessionKey: string): void;
+```
+
+### 6.2 扩展 `RunLogContext`
+
+`src/runner.ts` 的 `RunLogContext` 增加：
+
+```ts
+sessionKey?: string;
+recentTurns?: ConversationTurn[];
+```
+
+### 6.3 渠道传递会话信息
+
+Telegram、Feishu、WeChat 在调用 `dispatch()` 时传入同一个固定 key：
+
+```ts
+sessionKey: "im",
+```
+
+Scheduler 和 CLI 不传。
+
+### 6.4 路由和执行注入
+
+`routeProject()` 和 `runTask()` 接收最近轮次，分别拼入路由提示和执行系统提示。
+
+## 7. 配置
+
+新增配置：
+
+```text
+# 最近几轮用户可见对话会作为上下文注入
+CONVERSATION_CONTEXT_ENABLED=1
+CONVERSATION_CONTEXT_TURNS=5
+CONVERSATION_TURN_MAX_CHARS=4000
+```
+
+默认值：
+
+```text
+enabled = true
+maxTurns = 5
+maxCharsPerMessage = 4000
+```
+
+`CONVERSATION_TURN_MAX_CHARS` 是单条 `user` 或 `assistant` 消息上限，不是 N 轮总上限；先保持 4000，如果后续观察到正常回复被截断，再调高。
+
+不新增 TTL 配置。
+
+## 8. 边界场景
+
+| 场景 | 处理 |
+|------|------|
+| 用户只回复“确认/好的” | 路由阶段看到历史，优先落到上一项目 |
+| 用户开始明确的新任务 | 路由模型忽略旧历史，按新任务判断 |
+| 模型误判 | 用户纠正，纠正消息进入上下文，后续可修正 |
+| 历史超过 N 轮 | 最旧一轮滚动丢弃 |
+| 昨天问、今天确认 | 没有 TTL，仍可继续 |
+| Scheduler 消息 | 不加载用户聊天上下文 |
+| Self-heal | 不读取、不写入聊天上下文 |
+| CLI 调试 | 默认不启用上下文 |
+| 超长单轮回复 | 按字符上限截断 |
+
+## 9. 测试范围
+
+至少覆盖：
+
+- 最近 N 轮加载顺序。
+- 超过 N 轮后旧轮淘汰。
+- 单条消息字符截断。
+- `phase === "self-heal"` 不读取、不写入。
+- `duplicate`、`validation-failed`、`error` 不写入。
+- `unknown-project` 且存在最终 assistant 回复时写入，`project` 为 `null`。
+- Scheduler/CLI 不加载历史。
+- 历史路由提示能包含旧任务信息。
+- 多项目历史下，“确认”能路由到最近一个有 `project` 的轮。
+- 上下文注入后的 token 增长不会导致长系统提示词被截断；必要时截断历史或降低 N。
+
+## 10. 后续演进
+
+当前阶段不实现，但后续如果出现长任务或跨很多轮确认需求，可以在此基础上逐步增加：
+
+- 按项目过滤历史。
+- 只保留“最近一次未完成问题”作为轻量 pending 状态。
+- 使用 `pi-agent-core` 已有的 compaction 能力做摘要，而不是回到完整 CodeBuddy 架构。

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"restart": "bash scripts/botlerctl.sh restart",
 		"init": "tsx src/init.ts",
 		"typecheck": "tsc --noEmit",
-		"test": "tsx --test src/scheduler/cron.test.ts src/scheduler/store.test.ts src/scheduler/history.test.ts src/logging/store.test.ts src/monitor/stats.test.ts src/greeting.test.ts src/channels/wechat/aes-ecb.test.ts src/channels/wechat/download.test.ts src/channels/wechat/image-batch.test.ts src/conversation/store.test.ts",
+		"test": "tsx --test src/scheduler/cron.test.ts src/scheduler/store.test.ts src/scheduler/history.test.ts src/logging/store.test.ts src/monitor/stats.test.ts src/greeting.test.ts src/channels/allowlist.test.ts src/channels/wechat/aes-ecb.test.ts src/channels/wechat/download.test.ts src/channels/wechat/image-batch.test.ts src/conversation/store.test.ts",
 		"webui": "tsx src/webui/server.ts",
 		"cli": "tsx src/index.ts"
 	},

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"restart": "bash scripts/botlerctl.sh restart",
 		"init": "tsx src/init.ts",
 		"typecheck": "tsc --noEmit",
-		"test": "tsx --test src/scheduler/cron.test.ts src/scheduler/store.test.ts src/scheduler/history.test.ts src/logging/store.test.ts src/monitor/stats.test.ts src/greeting.test.ts src/channels/wechat/aes-ecb.test.ts src/channels/wechat/download.test.ts src/channels/wechat/image-batch.test.ts",
+		"test": "tsx --test src/scheduler/cron.test.ts src/scheduler/store.test.ts src/scheduler/history.test.ts src/logging/store.test.ts src/monitor/stats.test.ts src/greeting.test.ts src/channels/wechat/aes-ecb.test.ts src/channels/wechat/download.test.ts src/channels/wechat/image-batch.test.ts src/conversation/store.test.ts",
 		"webui": "tsx src/webui/server.ts",
 		"cli": "tsx src/index.ts"
 	},

--- a/src/channels/allowlist.test.ts
+++ b/src/channels/allowlist.test.ts
@@ -1,0 +1,16 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isAllowedSender } from "./allowlist.ts";
+
+test("empty allowlist allows everyone", () => {
+	assert.equal(isAllowedSender(undefined, ["123", "alice"]), true);
+	assert.equal(isAllowedSender("", ["123"]), true);
+	assert.equal(isAllowedSender(" , ", ["123"]), true);
+});
+
+test("non-empty allowlist requires an exact identity match", () => {
+	assert.equal(isAllowedSender("123, alice", ["alice"]), true);
+	assert.equal(isAllowedSender("123, alice", ["bob"]), false);
+	assert.equal(isAllowedSender("123", ["123", "alice"]), true);
+	assert.equal(isAllowedSender("123", [undefined, ""]), false);
+});

--- a/src/channels/allowlist.ts
+++ b/src/channels/allowlist.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared channel sender allowlist helper.
+ *
+ * Empty/unset allowlist means allow all, preserving the previous personal-deploy behavior.
+ * Once configured, at least one candidate identity must match exactly.
+ */
+export function isAllowedSender(rawAllowlist: string | undefined, identities: ReadonlyArray<string | undefined>): boolean {
+	const allowed = (rawAllowlist ?? "")
+		.split(",")
+		.map((item) => item.trim())
+		.filter(Boolean);
+	if (allowed.length === 0) return true;
+	return identities.some((identity) => {
+		if (typeof identity !== "string") return false;
+		const cleaned = identity.trim();
+		return cleaned.length > 0 && allowed.includes(cleaned);
+	});
+}

--- a/src/channels/feishu.ts
+++ b/src/channels/feishu.ts
@@ -3,7 +3,9 @@ import { createHash, createDecipheriv } from "node:crypto";
 import { CONFIG } from "../config.ts";
 import { dispatch } from "../dispatcher.ts";
 import { IM_SESSION_KEY } from "../conversation/store.ts";
+import { recordContact } from "../push/contacts.ts";
 import { setChannelUp, setChannelDown } from "../monitor/stats.ts";
+import { isAllowedSender } from "./allowlist.ts";
 
 const FEISHU_API = "https://open.feishu.cn/open-apis";
 
@@ -158,6 +160,20 @@ export function startFeishu(): void {
 				const chatId = message.chat_id;
 				const messageId = message.message_id;
 				const messageType = message.message_type;
+				const senderId = event.event.sender?.sender_id;
+				const senderIdentities = [
+					chatId ? String(chatId) : undefined,
+					senderId?.open_id,
+					senderId?.user_id,
+					senderId?.union_id,
+				];
+				if (!isAllowedSender(CONFIG.feishuAllowFrom, senderIdentities)) {
+					console.log(
+						`[feishu] ignoring sender outside allowlist: chat=${chatId ?? "(unknown)"} sender=${senderId?.open_id ?? senderId?.user_id ?? "(unknown)"}`,
+					);
+					sendJson(res, 200, {});
+					return;
+				}
 				let text = "";
 				if (messageType === "text") {
 					try {
@@ -167,10 +183,16 @@ export function startFeishu(): void {
 					}
 				}
 				if (text) {
-					const reply = await dispatch(text, { id: messageId, source: "feishu", sessionKey: IM_SESSION_KEY });
+					recordContact("feishu", String(chatId));
+					const reply = await dispatch(text, {
+						id: messageId,
+						source: "feishu",
+						recipient: { source: "feishu", userId: String(chatId) },
+						sessionKey: IM_SESSION_KEY,
+					});
 					// Text-only channel: an images-only reply still needs a non-empty body
 					const body = reply.text || "(image generated, but the Feishu channel does not support sending images yet)";
-					await replyFeishu(chatId, body).catch((e) =>
+					await replyFeishu(String(chatId), body).catch((e) =>
 						console.error("[feishu] Failed to reply:", e instanceof Error ? e.message : e),
 					);
 				}

--- a/src/channels/feishu.ts
+++ b/src/channels/feishu.ts
@@ -2,6 +2,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from "node:ht
 import { createHash, createDecipheriv } from "node:crypto";
 import { CONFIG } from "../config.ts";
 import { dispatch } from "../dispatcher.ts";
+import { IM_SESSION_KEY } from "../conversation/store.ts";
 import { setChannelUp, setChannelDown } from "../monitor/stats.ts";
 
 const FEISHU_API = "https://open.feishu.cn/open-apis";
@@ -166,7 +167,7 @@ export function startFeishu(): void {
 					}
 				}
 				if (text) {
-					const reply = await dispatch(text, { id: messageId, source: "feishu" });
+					const reply = await dispatch(text, { id: messageId, source: "feishu", sessionKey: IM_SESSION_KEY });
 					// Text-only channel: an images-only reply still needs a non-empty body
 					const body = reply.text || "(image generated, but the Feishu channel does not support sending images yet)";
 					await replyFeishu(chatId, body).catch((e) =>

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -3,6 +3,7 @@ import { HttpsProxyAgent } from "https-proxy-agent";
 import { CONFIG } from "../config.ts";
 import { dispatch } from "../dispatcher.ts";
 import { recordContact } from "../push/contacts.ts";
+import { IM_SESSION_KEY } from "../conversation/store.ts";
 import { setChannelUp, setChannelDown } from "../monitor/stats.ts";
 
 /** Module-level bot instance (set by startTelegram); used by push delivery. */
@@ -77,6 +78,7 @@ export function startTelegram(): void {
 				id: `${chatId}:${messageId}`,
 				source: "telegram",
 				recipient: { source: "telegram", userId: String(chatId) },
+				sessionKey: IM_SESSION_KEY,
 			});
 			// Text-only channel: images the agent produced are not sent here, so an
 			// images-only reply still needs a non-empty body (Telegram rejects empty text).

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -5,6 +5,7 @@ import { dispatch } from "../dispatcher.ts";
 import { recordContact } from "../push/contacts.ts";
 import { IM_SESSION_KEY } from "../conversation/store.ts";
 import { setChannelUp, setChannelDown } from "../monitor/stats.ts";
+import { isAllowedSender } from "./allowlist.ts";
 
 /** Module-level bot instance (set by startTelegram); used by push delivery. */
 let bot: Bot | null = null;
@@ -70,14 +71,21 @@ export function startTelegram(): void {
 			console.log("[tg] Ignored non-text / no-chat message");
 			return;
 		}
+		const fromId = ctx.from?.id !== undefined ? String(ctx.from.id) : undefined;
+		const username = ctx.from?.username;
+		const chatIdText = String(chatId);
+		if (!isAllowedSender(CONFIG.telegramAllowFrom, [fromId, username, chatIdText])) {
+			console.log(`[tg] Ignoring sender outside allowlist: from=${fromId ?? username ?? "(unknown)"} chat=${chatIdText}`);
+			return;
+		}
 		console.log(`[tg] Processing chat=${chatId} msg=${messageId}: ${JSON.stringify(text.slice(0, 60))}`);
 		try {
 			// Remember this address so push delivery can fall back to Telegram when the primary channel fails.
-			recordContact("telegram", String(chatId));
+			recordContact("telegram", chatIdText);
 			const reply = await dispatch(text, {
 				id: `${chatId}:${messageId}`,
 				source: "telegram",
-				recipient: { source: "telegram", userId: String(chatId) },
+				recipient: { source: "telegram", userId: chatIdText },
 				sessionKey: IM_SESSION_KEY,
 			});
 			// Text-only channel: images the agent produced are not sent here, so an

--- a/src/channels/wechat/monitor.ts
+++ b/src/channels/wechat/monitor.ts
@@ -1,5 +1,6 @@
 import { CONFIG } from "../../config.ts";
 import { dispatch, DUPLICATE_SENTINEL } from "../../dispatcher.ts";
+import { IM_SESSION_KEY } from "../../conversation/store.ts";
 import { recordContact } from "../../push/contacts.ts";
 import { getUpdates } from "./api.ts";
 import { loadSyncBuf, saveSyncBuf, resolveAccount } from "./account.ts";
@@ -210,6 +211,7 @@ async function dispatchAndReply(params: {
 			source: "wechat",
 			recipient: { source: "wechat", userId: fromUserId },
 			inboundImages,
+			sessionKey: IM_SESSION_KEY,
 		});
 		// Dedup hit returns a sentinel; don't echo it back to the user
 		if (reply.text === DUPLICATE_SENTINEL) return;

--- a/src/config.ts
+++ b/src/config.ts
@@ -129,6 +129,14 @@ export interface Config {
 	monitorPort: number;
 	/** Max tool-call turns for a single execution Agent (one assistant message with >=1 toolCall counts as 1 turn). Default 20. */
 	maxToolTurns: number;
+	/** When true, inject the recent IM conversation window into routing and execution prompts. */
+	conversationContextEnabled: boolean;
+	/** Number of recent visible turns kept per conversation session. */
+	conversationContextTurns: number;
+	/** Max characters kept for each stored user or assistant message. */
+	conversationTurnMaxChars: number;
+	/** Directory for the conversation session files (outside DATA_ROOT). */
+	conversationDir: string;
 }
 
 /**
@@ -220,6 +228,23 @@ function parseMaxToolTurns(): number {
 	return Number.isInteger(n) && n >= 1 ? n : 20;
 }
 
+/** Parse CONVERSATION_CONTEXT_ENABLED; only "0" disables it (default enabled). */
+function parseConversationContextEnabled(): boolean {
+	return process.env.CONVERSATION_CONTEXT_ENABLED !== "0";
+}
+
+/** Parse CONVERSATION_CONTEXT_TURNS; 0 disables injection, invalid values fall back to 5. */
+function parseConversationContextTurns(): number {
+	const n = Number(process.env.CONVERSATION_CONTEXT_TURNS ?? "5");
+	return Number.isInteger(n) && n >= 0 ? n : 5;
+}
+
+/** Parse CONVERSATION_TURN_MAX_CHARS; invalid or non-positive values fall back to 4000. */
+function parseConversationTurnMaxChars(): number {
+	const n = Number(process.env.CONVERSATION_TURN_MAX_CHARS ?? "4000");
+	return Number.isFinite(n) && n >= 1 ? Math.floor(n) : 4000;
+}
+
 /**
  * Parse WECHAT_REMINDER_HOURS. Single parse branch (avoids `Number(env)||23` letting 0<x<1 /
  * negative values through):
@@ -271,6 +296,10 @@ export const CONFIG: Config = {
 		"https://raw.githubusercontent.com/NateScarlet/holiday-cn/master/{year}.json",
 	logDir: process.env.BOTLER_LOG_DIR ?? join(USER_CONFIG_DIR, "task-logs"),
 	maxToolTurns: parseMaxToolTurns(),
+	conversationContextEnabled: parseConversationContextEnabled(),
+	conversationContextTurns: parseConversationContextTurns(),
+	conversationTurnMaxChars: parseConversationTurnMaxChars(),
+	conversationDir: join(USER_CONFIG_DIR, "conversations"),
 	monitorEnabled: process.env.MONITOR_ENABLED !== "0",
 	monitorPort: (() => {
 		const n = Number(process.env.MONITOR_PORT ?? "8899");

--- a/src/config.ts
+++ b/src/config.ts
@@ -87,11 +87,15 @@ export interface Config {
 	/** Custom OpenAI-completions providers (from ~/.botler-agent/providers.json, with a legacy CUSTOM_* env fallback). */
 	customProviders: CustomProviderConfig[];
 	telegramToken?: string;
+	/** Optional comma-separated Telegram sender allowlist (user ids or usernames); empty = allow all. */
+	telegramAllowFrom?: string;
 	feishuAppId?: string;
 	feishuAppSecret?: string;
 	feishuVerificationToken?: string;
 	feishuEncryptKey?: string;
 	feishuPort: number;
+	/** Optional comma-separated Feishu allowlist (sender open_id/user_id/union_id or chat_id); empty = allow all. */
+	feishuAllowFrom?: string;
 	/** When WECHAT_ENABLED=1, start the WeChat iLink long-poll channel (requires a completed wechat-login). */
 	wechatEnabled: boolean;
 	/** Optional comma-separated extra ilink_user_id allowlist; the account owner (QR scanner) is always allowed. */
@@ -135,6 +139,8 @@ export interface Config {
 	conversationContextTurns: number;
 	/** Max characters kept for each stored user or assistant message. */
 	conversationTurnMaxChars: number;
+	/** Whole-window character cap for injected conversation context. */
+	conversationContextMaxChars: number;
 	/** Directory for the conversation session files (outside DATA_ROOT). */
 	conversationDir: string;
 }
@@ -245,6 +251,12 @@ function parseConversationTurnMaxChars(): number {
 	return Number.isFinite(n) && n >= 1 ? Math.floor(n) : 4000;
 }
 
+/** Parse CONVERSATION_CONTEXT_MAX_CHARS; invalid or non-positive values fall back to 12000. */
+function parseConversationContextMaxChars(): number {
+	const n = Number(process.env.CONVERSATION_CONTEXT_MAX_CHARS ?? "12000");
+	return Number.isFinite(n) && n >= 1 ? Math.floor(n) : 12000;
+}
+
 /**
  * Parse WECHAT_REMINDER_HOURS. Single parse branch (avoids `Number(env)||23` letting 0<x<1 /
  * negative values through):
@@ -276,11 +288,13 @@ export const CONFIG: Config = {
 	model: process.env.PI_MODEL ?? "claude-sonnet-4-5",
 	customProviders: buildCustomProviders(),
 	telegramToken: process.env.TELEGRAM_BOT_TOKEN || undefined,
+	telegramAllowFrom: process.env.TELEGRAM_ALLOW_FROM || undefined,
 	feishuAppId: process.env.FEISHU_APP_ID || undefined,
 	feishuAppSecret: process.env.FEISHU_APP_SECRET || undefined,
 	feishuVerificationToken: process.env.FEISHU_VERIFICATION_TOKEN || undefined,
 	feishuEncryptKey: process.env.FEISHU_ENCRYPT_KEY || undefined,
 	feishuPort: Number(process.env.FEISHU_PORT ?? "3000"),
+	feishuAllowFrom: process.env.FEISHU_ALLOW_FROM || undefined,
 	wechatEnabled: process.env.WECHAT_ENABLED === "1",
 	wechatAllowFrom: process.env.WECHAT_ALLOW_FROM || undefined,
 	wechatReminderHours: parseWechatReminderHours(),
@@ -299,6 +313,7 @@ export const CONFIG: Config = {
 	conversationContextEnabled: parseConversationContextEnabled(),
 	conversationContextTurns: parseConversationContextTurns(),
 	conversationTurnMaxChars: parseConversationTurnMaxChars(),
+	conversationContextMaxChars: parseConversationContextMaxChars(),
 	conversationDir: join(USER_CONFIG_DIR, "conversations"),
 	monitorEnabled: process.env.MONITOR_ENABLED !== "0",
 	monitorPort: (() => {

--- a/src/conversation/store.test.ts
+++ b/src/conversation/store.test.ts
@@ -1,0 +1,103 @@
+import { before, test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ConversationTurn } from "./store.ts";
+
+let store: typeof import("./store.ts");
+let systemPrompt: typeof import("../prompts/system-prompt.ts");
+
+before(async () => {
+	const tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "botler-conversation-")));
+	process.env.BOTLER_CONFIG_DIR = tmp;
+	process.env.CONVERSATION_CONTEXT_TURNS = "5";
+	process.env.CONVERSATION_TURN_MAX_CHARS = "20";
+	store = await import("./store.ts");
+	systemPrompt = await import("../prompts/system-prompt.ts");
+});
+
+function turn(n: number, project: string | null = "cook"): ConversationTurn {
+	return {
+		ts: 1_000 + n,
+		project,
+		user: `user-${n}`,
+		assistant: `assistant-${n}`,
+		imageRefs: [],
+	};
+}
+
+test("loadRecentTurns returns the newest N turns oldest-to-newest", () => {
+	store.clearSession(store.IM_SESSION_KEY);
+	for (let i = 1; i <= 3; i++) store.appendTurn(store.IM_SESSION_KEY, turn(i), 5);
+	const turns = store.loadRecentTurns(store.IM_SESSION_KEY, 5);
+	assert.deepEqual(
+		turns.map((t) => t.user),
+		["user-1", "user-2", "user-3"],
+	);
+});
+
+test("appendTurn drops turns older than the sliding window", () => {
+	store.clearSession(store.IM_SESSION_KEY);
+	for (let i = 1; i <= 7; i++) store.appendTurn(store.IM_SESSION_KEY, turn(i), 5);
+	const turns = store.loadRecentTurns(store.IM_SESSION_KEY, 5);
+	assert.deepEqual(
+		turns.map((t) => t.user),
+		["user-3", "user-4", "user-5", "user-6", "user-7"],
+	);
+});
+
+test("appendTurn truncates user and assistant messages to the configured max chars", () => {
+	store.clearSession(store.IM_SESSION_KEY);
+	store.appendTurn(
+		store.IM_SESSION_KEY,
+		{
+			ts: 1,
+			project: "cook",
+			user: "u".repeat(40),
+			assistant: "a".repeat(40),
+			imageRefs: ["cook/photos/example.jpg"],
+		},
+		5,
+	);
+	const [stored] = store.loadRecentTurns(store.IM_SESSION_KEY, 5);
+	assert.equal(stored.user.length, 20);
+	assert.equal(stored.assistant.length, 20);
+	assert.deepEqual(stored.imageRefs, ["cook/photos/example.jpg"]);
+});
+
+test("shouldRecordTurn only records execute-phase success/auto-fixed/unknown-project with a session", () => {
+	assert.equal(store.shouldRecordTurn("execute", "success", store.IM_SESSION_KEY), true);
+	assert.equal(store.shouldRecordTurn("execute", "auto-fixed", store.IM_SESSION_KEY), true);
+	assert.equal(store.shouldRecordTurn("execute", "unknown-project", store.IM_SESSION_KEY), true);
+	assert.equal(store.shouldRecordTurn("execute", "validation-failed", store.IM_SESSION_KEY), false);
+	assert.equal(store.shouldRecordTurn("execute", "error", store.IM_SESSION_KEY), false);
+	assert.equal(store.shouldRecordTurn("execute", "duplicate", store.IM_SESSION_KEY), false);
+	assert.equal(store.shouldRecordTurn("self-heal", "success", store.IM_SESSION_KEY), false);
+	assert.equal(store.shouldRecordTurn("execute", "success"), false);
+});
+
+test("formatRecentTurns includes project labels only when requested", () => {
+	const turns = [turn(1, "cook")];
+	assert.equal(store.formatRecentTurns(turns), "用户：user-1\nBot：assistant-1");
+	assert.equal(
+		store.formatRecentTurns(turns, { includeProject: true }),
+		"（项目：cook）用户：user-1\nBot：assistant-1",
+	);
+});
+
+test("buildRoutePrompt includes the recent user-visible conversation", () => {
+	const turns = [turn(1, "cook")];
+	const prompt = systemPrompt.buildRoutePrompt("确认", true, false, turns);
+	assert.match(prompt, /最近对话/);
+	assert.match(prompt, /用户：user-1/);
+	assert.match(prompt, /Bot：assistant-1/);
+	assert.match(prompt, /确认/);
+});
+
+test("clearSession removes the stored conversation file", () => {
+	store.clearSession(store.IM_SESSION_KEY);
+	store.appendTurn(store.IM_SESSION_KEY, turn(1), 5);
+	store.clearSession(store.IM_SESSION_KEY);
+	assert.deepEqual(store.loadRecentTurns(store.IM_SESSION_KEY, 5), []);
+});

--- a/src/conversation/store.test.ts
+++ b/src/conversation/store.test.ts
@@ -13,6 +13,7 @@ before(async () => {
 	process.env.BOTLER_CONFIG_DIR = tmp;
 	process.env.CONVERSATION_CONTEXT_TURNS = "5";
 	process.env.CONVERSATION_TURN_MAX_CHARS = "20";
+	process.env.CONVERSATION_CONTEXT_MAX_CHARS = "80";
 	store = await import("./store.ts");
 	systemPrompt = await import("../prompts/system-prompt.ts");
 });
@@ -23,7 +24,6 @@ function turn(n: number, project: string | null = "cook"): ConversationTurn {
 		project,
 		user: `user-${n}`,
 		assistant: `assistant-${n}`,
-		imageRefs: [],
 	};
 }
 
@@ -47,6 +47,12 @@ test("appendTurn drops turns older than the sliding window", () => {
 	);
 });
 
+test("appendTurn preserves a null project for unknown-project turns", () => {
+	store.clearSession(store.IM_SESSION_KEY);
+	store.appendTurn(store.IM_SESSION_KEY, turn(1, null), 5);
+	assert.equal(store.loadRecentTurns(store.IM_SESSION_KEY, 5)[0].project, null);
+});
+
 test("appendTurn truncates user and assistant messages to the configured max chars", () => {
 	store.clearSession(store.IM_SESSION_KEY);
 	store.appendTurn(
@@ -56,14 +62,12 @@ test("appendTurn truncates user and assistant messages to the configured max cha
 			project: "cook",
 			user: "u".repeat(40),
 			assistant: "a".repeat(40),
-			imageRefs: ["cook/photos/example.jpg"],
 		},
 		5,
 	);
 	const [stored] = store.loadRecentTurns(store.IM_SESSION_KEY, 5);
 	assert.equal(stored.user.length, 20);
 	assert.equal(stored.assistant.length, 20);
-	assert.deepEqual(stored.imageRefs, ["cook/photos/example.jpg"]);
 });
 
 test("shouldRecordTurn only records execute-phase success/auto-fixed/unknown-project with a session", () => {
@@ -75,6 +79,7 @@ test("shouldRecordTurn only records execute-phase success/auto-fixed/unknown-pro
 	assert.equal(store.shouldRecordTurn("execute", "duplicate", store.IM_SESSION_KEY), false);
 	assert.equal(store.shouldRecordTurn("self-heal", "success", store.IM_SESSION_KEY), false);
 	assert.equal(store.shouldRecordTurn("execute", "success"), false);
+	assert.equal(store.shouldRecordTurn("execute", "unknown-project", store.IM_SESSION_KEY, false), false);
 });
 
 test("formatRecentTurns includes project labels only when requested", () => {
@@ -84,6 +89,34 @@ test("formatRecentTurns includes project labels only when requested", () => {
 		store.formatRecentTurns(turns, { includeProject: true }),
 		"（项目：cook）用户：user-1\nBot：assistant-1",
 	);
+});
+
+test("formatRecentTurns separates turns with blank lines and a horizontal rule", () => {
+	const turns = [turn(1, "cook"), turn(2, "cook")];
+	assert.equal(
+		store.formatRecentTurns(turns, { maxChars: 1000 }),
+		"用户：user-1\nBot：assistant-1\n\n---\n\n用户：user-2\nBot：assistant-2",
+	);
+});
+
+test("formatRecentTurns drops oldest turns first when the whole-window cap is exceeded", () => {
+	const turns = [
+		{ ts: 1, project: "cook", user: "old-user", assistant: "old-assistant" },
+		{ ts: 2, project: "cook", user: "new-user", assistant: "new-assistant" },
+	];
+	const formatted = store.formatRecentTurns(turns, { maxChars: 29 });
+	assert.equal(formatted, "用户：new-user\nBot：new-assistant");
+	assert.doesNotMatch(formatted, /old-user/);
+});
+
+test("shouldLoadRecentTurns only loads execute-phase IM sessions", () => {
+	const base = { enabled: true, source: "telegram", sessionKey: store.IM_SESSION_KEY };
+	assert.equal(store.shouldLoadRecentTurns({ ...base, phase: "execute" }), true);
+	assert.equal(store.shouldLoadRecentTurns({ ...base, phase: "self-heal" }), false);
+	assert.equal(store.shouldLoadRecentTurns({ ...base, source: "scheduler", phase: "execute" }), false);
+	assert.equal(store.shouldLoadRecentTurns({ ...base, source: "cli", phase: "execute" }), false);
+	assert.equal(store.shouldLoadRecentTurns({ ...base, enabled: false, phase: "execute" }), false);
+	assert.equal(store.shouldLoadRecentTurns({ enabled: true, source: "telegram", phase: "execute" }), false);
 });
 
 test("buildRoutePrompt includes the recent user-visible conversation", () => {

--- a/src/conversation/store.ts
+++ b/src/conversation/store.ts
@@ -1,0 +1,146 @@
+/**
+ * Persistent recent-conversation store.
+ *
+ * The framework keeps only the user-visible turns (user message + final Bot reply) for the
+ * shared IM session. This file lives outside DATA_ROOT and is intentionally small: no agent
+ * thinking, tool calls, or tool results are stored here; those remain in task-logs.
+ */
+
+import { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { CONFIG } from "../config.ts";
+
+/** Fixed conversation key used by Telegram / Feishu / WeChat. */
+export const IM_SESSION_KEY = "im";
+
+export interface ConversationTurn {
+	/** Epoch ms of the turn's start. */
+	ts: number;
+	/** Routed data subproject; null when the reply did not target a project. */
+	project: string | null;
+	/** User-visible input text. */
+	user: string;
+	/** User-visible final Bot reply text. */
+	assistant: string;
+	/** Inbound-image references persisted by this turn. */
+	imageRefs: string[];
+}
+
+const SESSION_KEY_RE = /^[a-z0-9_-]+$/i;
+
+function sessionFile(sessionKey: string): string {
+	if (!SESSION_KEY_RE.test(sessionKey)) throw new Error(`invalid conversation session key: ${sessionKey}`);
+	return join(CONFIG.conversationDir, `${sessionKey}.json`);
+}
+
+function normalizeProject(value: unknown): string | null {
+	return typeof value === "string" && value ? value : null;
+}
+
+function normalizeImageRefs(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	return value
+		.filter((item): item is string => typeof item === "string")
+		.map((item) => item.trim())
+		.filter(Boolean);
+}
+
+function normalizeTurn(value: unknown): ConversationTurn | null {
+	if (!value || typeof value !== "object") return null;
+	const raw = value as Record<string, unknown>;
+	const ts = Number(raw.ts);
+	if (!Number.isFinite(ts)) return null;
+	const user = typeof raw.user === "string" ? raw.user.slice(0, CONFIG.conversationTurnMaxChars) : "";
+	const assistant = typeof raw.assistant === "string" ? raw.assistant.slice(0, CONFIG.conversationTurnMaxChars) : "";
+	if (!user && !assistant) return null;
+	return {
+		ts,
+		project: normalizeProject(raw.project),
+		user,
+		assistant,
+		imageRefs: normalizeImageRefs(raw.imageRefs),
+	};
+}
+
+/** Read the full persisted turn list. Corrupt/missing files degrade to an empty list. */
+function readTurns(sessionKey: string): ConversationTurn[] {
+	try {
+		const raw = JSON.parse(readFileSync(sessionFile(sessionKey), "utf8")) as { turns?: unknown };
+		if (!raw || !Array.isArray(raw.turns)) return [];
+		return raw.turns
+			.map(normalizeTurn)
+			.filter((turn): turn is ConversationTurn => turn !== null);
+	} catch {
+		return [];
+	}
+}
+
+/** Load the newest `maxTurns` turns, ordered oldest -> newest. */
+export function loadRecentTurns(sessionKey: string, maxTurns: number): ConversationTurn[] {
+	if (!Number.isInteger(maxTurns) || maxTurns <= 0) return [];
+	return readTurns(sessionKey).slice(-maxTurns);
+}
+
+/** Append a normalized turn and keep only the newest `maxTurns` entries. */
+export function appendTurn(sessionKey: string, turn: ConversationTurn, maxTurns: number): void {
+	if (!Number.isInteger(maxTurns) || maxTurns <= 0) return;
+	try {
+		const normalized = normalizeTurn(turn);
+		if (!normalized) return;
+		const turns = readTurns(sessionKey);
+		turns.push(normalized);
+		const kept = turns.slice(-maxTurns);
+		const file = sessionFile(sessionKey);
+		mkdirSync(CONFIG.conversationDir, { recursive: true, mode: 0o700 });
+		const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
+		writeFileSync(tmp, JSON.stringify({ turns: kept }, null, 2) + "\n", {
+			encoding: "utf8",
+			mode: 0o600,
+		});
+		renameSync(tmp, file);
+	} catch (e) {
+		// Conversation history must never break the main dispatch flow.
+		console.error("[conversation] appendTurn failed:", e instanceof Error ? e.message : e);
+	}
+}
+
+/** Remove a conversation session file (best-effort). */
+export function clearSession(sessionKey: string): void {
+	try {
+		unlinkSync(sessionFile(sessionKey));
+	} catch (e) {
+		const err = e as NodeJS.ErrnoException;
+		if (err.code !== "ENOENT") {
+			console.error("[conversation] clearSession failed:", e instanceof Error ? e.message : e);
+		}
+	}
+}
+
+/**
+ * Render recent turns for prompt injection. `includeProject` is useful in the routing phase,
+ * where the model should preferentially continue the most recent routed project.
+ */
+export function formatRecentTurns(
+	turns: readonly ConversationTurn[],
+	opts: { includeProject?: boolean } = {},
+): string {
+	if (turns.length === 0) return "";
+	return turns
+		.map((turn) => {
+			const project = opts.includeProject && turn.project ? `（项目：${turn.project}）` : "";
+			return `${project}用户：${turn.user}\nBot：${turn.assistant}`;
+		})
+		.join("\n");
+}
+
+export type RecordableTaskStatus = "success" | "auto-fixed" | "unknown-project";
+
+/** Whether a completed execution should be appended to the shared IM history. */
+export function shouldRecordTurn(
+	phase: "execute" | "self-heal",
+	status: string,
+	sessionKey?: string,
+): status is RecordableTaskStatus {
+	if (phase !== "execute" || !sessionKey) return false;
+	return status === "success" || status === "auto-fixed" || status === "unknown-project";
+}

--- a/src/conversation/store.ts
+++ b/src/conversation/store.ts
@@ -6,7 +6,7 @@
  * thinking, tool calls, or tool results are stored here; those remain in task-logs.
  */
 
-import { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { closeSync, fsyncSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { CONFIG } from "../config.ts";
 
@@ -22,8 +22,6 @@ export interface ConversationTurn {
 	user: string;
 	/** User-visible final Bot reply text. */
 	assistant: string;
-	/** Inbound-image references persisted by this turn. */
-	imageRefs: string[];
 }
 
 const SESSION_KEY_RE = /^[a-z0-9_-]+$/i;
@@ -35,14 +33,6 @@ function sessionFile(sessionKey: string): string {
 
 function normalizeProject(value: unknown): string | null {
 	return typeof value === "string" && value ? value : null;
-}
-
-function normalizeImageRefs(value: unknown): string[] {
-	if (!Array.isArray(value)) return [];
-	return value
-		.filter((item): item is string => typeof item === "string")
-		.map((item) => item.trim())
-		.filter(Boolean);
 }
 
 function normalizeTurn(value: unknown): ConversationTurn | null {
@@ -58,7 +48,6 @@ function normalizeTurn(value: unknown): ConversationTurn | null {
 		project: normalizeProject(raw.project),
 		user,
 		assistant,
-		imageRefs: normalizeImageRefs(raw.imageRefs),
 	};
 }
 
@@ -97,6 +86,14 @@ export function appendTurn(sessionKey: string, turn: ConversationTurn, maxTurns:
 			encoding: "utf8",
 			mode: 0o600,
 		});
+		// fsync before rename so a hard kill cannot leave a zero-length `.tmp` file that
+		// looks like the intended destination while the original was already removed.
+		const fd = openSync(tmp, "r+");
+		try {
+			fsyncSync(fd);
+		} finally {
+			closeSync(fd);
+		}
 		renameSync(tmp, file);
 	} catch (e) {
 		// Conversation history must never break the main dispatch flow.
@@ -122,15 +119,30 @@ export function clearSession(sessionKey: string): void {
  */
 export function formatRecentTurns(
 	turns: readonly ConversationTurn[],
-	opts: { includeProject?: boolean } = {},
+	opts: { includeProject?: boolean; maxChars?: number } = {},
 ): string {
 	if (turns.length === 0) return "";
-	return turns
-		.map((turn) => {
-			const project = opts.includeProject && turn.project ? `（项目：${turn.project}）` : "";
-			return `${project}用户：${turn.user}\nBot：${turn.assistant}`;
-		})
-		.join("\n");
+	const maxChars = opts.maxChars ?? CONFIG.conversationContextMaxChars;
+	if (!Number.isFinite(maxChars) || maxChars <= 0) return "";
+	const separator = "\n\n---\n\n";
+	const rendered = turns.map((turn) => {
+		const project = opts.includeProject && turn.project ? `（项目：${turn.project}）` : "";
+		return `${project}用户：${turn.user}\nBot：${turn.assistant}`;
+	});
+	// Keep the newest turns within the whole-window cap, dropping the oldest turns first.
+	const kept: string[] = [];
+	let used = 0;
+	for (let i = rendered.length - 1; i >= 0; i--) {
+		const piece = rendered[i];
+		const add = kept.length === 0 ? piece : `${separator}${piece}`;
+		if (used + add.length > maxChars) {
+			if (kept.length === 0) kept.push(piece.slice(0, maxChars));
+			break;
+		}
+		kept.unshift(piece);
+		used += add.length;
+	}
+	return kept.join(separator);
 }
 
 export type RecordableTaskStatus = "success" | "auto-fixed" | "unknown-project";
@@ -140,7 +152,26 @@ export function shouldRecordTurn(
 	phase: "execute" | "self-heal",
 	status: string,
 	sessionKey?: string,
+	recordable = true,
 ): status is RecordableTaskStatus {
-	if (phase !== "execute" || !sessionKey) return false;
+	if (!recordable || phase !== "execute" || !sessionKey) return false;
 	return status === "success" || status === "auto-fixed" || status === "unknown-project";
+}
+
+export interface RecentTurnLoadContext {
+	enabled: boolean;
+	phase: "execute" | "self-heal";
+	source: string;
+	sessionKey?: string;
+}
+
+/** Whether the runner should load the shared IM conversation for this run. */
+export function shouldLoadRecentTurns(ctx: RecentTurnLoadContext): boolean {
+	return (
+		ctx.enabled &&
+		ctx.phase === "execute" &&
+		ctx.source !== "scheduler" &&
+		ctx.source !== "cli" &&
+		Boolean(ctx.sessionKey)
+	);
 }

--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -68,19 +68,23 @@ function appendVisibleTurn(
 	status: TaskStatus,
 ): void {
 	if (!CONFIG.conversationContextEnabled) return;
-	if (!shouldRecordTurn("execute", status, sessionKey)) return;
+	if (!shouldRecordTurn("execute", status, sessionKey, result?.recordConversationTurn !== false)) return;
 	const log = result?.log;
 	if (!log) return;
-	const assistant = (log.replyText || result?.text || "").trim();
+	// Store the clean user-facing reply. For auto-fixed runs `log.replyText` carries the
+	// framework decoration "(auto-fixed and saved)", which is task-log metadata, not the
+	// visible assistant turn that should be reused as conversation context.
+	const assistant = (result?.text || log.replyText || "").trim();
 	if (!assistant) return;
 	appendTurn(
 		sessionKey!,
 		{
 			ts: log.startedAt,
 			project: log.project,
+			// The model sees an additional image-persisted note appended by the framework;
+			// history deliberately stores only the original user text, not that transport note.
 			user: message,
 			assistant,
-			imageRefs: result?.conversationImageRefs ?? [],
 		},
 		CONFIG.conversationContextTurns,
 	);

--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -4,6 +4,7 @@ import { validateState } from "./safety/validate.ts";
 import { commitIfChanged } from "./safety/git.ts";
 import { appendTaskLog } from "./logging/store.ts";
 import { CONFIG } from "./config.ts";
+import { appendTurn, shouldRecordTurn } from "./conversation/store.ts";
 import type { Recipient } from "./push/types.ts";
 import type { TaskLog, TaskStatus, TokenUsageLog } from "./logging/types.ts";
 import type { InboundImage } from "./channels/wechat/download.ts";
@@ -32,6 +33,8 @@ export interface DispatchOptions {
 	 * target subproject. WeChat-only for now. Distinct from DispatchResult.images (outbound).
 	 */
 	inboundImages?: InboundImage[];
+	/** Fixed conversation session key for IM channels; omitted for scheduler / CLI. */
+	sessionKey?: string;
 }
 
 export interface DispatchResult {
@@ -55,6 +58,32 @@ let chain: Promise<unknown> = Promise.resolve();
 function truncate(s: string, n = 60): string {
 	const flat = s.replace(/\s+/g, " ").trim();
 	return flat.length > n ? `${flat.slice(0, n)}…` : flat;
+}
+
+/** Append the user-visible turn when the execute phase completed with a recordable status. */
+function appendVisibleTurn(
+	sessionKey: string | undefined,
+	message: string,
+	result: TaskResult | undefined,
+	status: TaskStatus,
+): void {
+	if (!CONFIG.conversationContextEnabled) return;
+	if (!shouldRecordTurn("execute", status, sessionKey)) return;
+	const log = result?.log;
+	if (!log) return;
+	const assistant = (log.replyText || result?.text || "").trim();
+	if (!assistant) return;
+	appendTurn(
+		sessionKey!,
+		{
+			ts: log.startedAt,
+			project: log.project,
+			user: message,
+			assistant,
+			imageRefs: result?.conversationImageRefs ?? [],
+		},
+		CONFIG.conversationContextTurns,
+	);
 }
 
 const ZERO_USAGE: TokenUsageLog = {
@@ -155,6 +184,7 @@ export async function dispatch(message: string, opts: DispatchOptions = {}): Pro
 				projectHint: opts.projectHint,
 				recipient: opts.recipient,
 				inboundImages: opts.inboundImages,
+				sessionKey: opts.sessionKey,
 			});
 			const log = result.log;
 			if (!log) {
@@ -231,6 +261,7 @@ export async function dispatch(message: string, opts: DispatchOptions = {}): Pro
 			return out(errText, [], "error");
 		} finally {
 			// Single unified exit accounting: always fires, regardless of which branch returned.
+			appendVisibleTurn(opts.sessionKey, message, result, finalStatus);
 			markFinished();
 			recordStatus(finalStatus);
 			stats.lastDispatchDurationMs = Date.now() - dispatchStartedAt;

--- a/src/prompts/system-prompt.ts
+++ b/src/prompts/system-prompt.ts
@@ -1,6 +1,7 @@
 import { readFileSync, existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { CONFIG, USER_CONFIG_DIR } from "../config.ts";
+import { formatRecentTurns, type ConversationTurn } from "../conversation/store.ts";
 
 /**
  * Built-in generic default system prompt: only describes boundaries and generic working principles, with no specific business schema.
@@ -9,7 +10,9 @@ import { CONFIG, USER_CONFIG_DIR } from "../config.ts";
  */
 export const DEFAULT_SYSTEM_PROMPT = `你是运行在个人数据目录下的轻量助手。你只在 __DATA_ROOT__ 目录内的各数据子项目中工作，禁止访问目录外的任何文件或执行命令。
 
-你的能力：通过 read / write / edit / run 四个工具读写白名单内的 JSON 文件、执行项目内脚本，完成各数据子项目中的短任务；还可以用 schedule 工具创建 / 管理定时任务。每条消息都是一次独立任务，没有跨任务记忆。
+你的能力：通过 read / write / edit / run 四个工具读写白名单内的 JSON 文件、执行项目内脚本，完成各数据子项目中的短任务；还可以用 schedule 工具创建 / 管理定时任务。
+
+你拥有最近若干轮用户可见对话作为上下文。当前消息如果明显是新的独立任务，请忽略旧历史并按新任务处理；如果它是上一轮任务的确认、补充或纠正，请结合历史继续处理。无法确定时向用户确认。
 
 # 当前环境
 - 今天日期：__TODAY__（YYYY-MM-DD，本地时区；涉及「今天/昨天」等相对日期的任务以它为准）。
@@ -182,7 +185,12 @@ function schedulerContext(): string {
  * The virtual `__scheduler__` project is included as a candidate for schedule-management messages,
  * unless `includeScheduler` is false (scheduler-fired reminders are never schedule-management requests).
  */
-export function buildRoutePrompt(userMessage: string, includeScheduler = true, hasImages = false): string {
+export function buildRoutePrompt(
+	userMessage: string,
+	includeScheduler = true,
+	hasImages = false,
+	recentTurns: readonly ConversationTurn[] = [],
+): string {
 	const schedulerLine = includeScheduler
 		? `- ${SCHEDULER_VIRTUAL_PROJECT}/：仅用于创建/管理定时任务（与数据子项目无关）\n`
 		: "";
@@ -192,11 +200,17 @@ export function buildRoutePrompt(userMessage: string, includeScheduler = true, h
 	const imageLine = hasImages
 		? "\n本条消息附带图片。请同时参考图片内容与文字判断所属子项目：图片内容明显匹配某个子项目的描述（如食物照片 → 记录饮食的项目）时选择该项目；无法根据图片与文字确定时输出 UNKNOWN。\n"
 		: "";
+	const historyBlock = recentTurns.length
+		? `\n最近对话：\n${formatRecentTurns(recentTurns, { includeProject: true })}\n`
+		: "";
+	const historyInstruction = recentTurns.length
+		? "\n如果当前消息是上一轮任务的简短确认或补充，优先沿用最近对话对应的项目；如果当前消息明显是一个新的独立任务，忽略旧历史并按新任务判断；无法确定时输出 UNKNOWN。\n"
+		: "";
 	return `你是路由助手，负责判断用户消息要操作哪个数据子项目。只输出一个项目名（不含斜杠），无法确定时只输出 UNKNOWN。不要使用任何工具。
 
 数据根目录下的子项目：
-${listProjectSummaries()}${schedulerLine}用户消息：${userMessage}
-${imageLine}判断这条消息属于哪个子项目。只输出项目名（如 my-project）或 UNKNOWN。`;
+${listProjectSummaries()}${schedulerLine}${historyBlock}用户消息：${userMessage}
+${imageLine}${historyInstruction}判断这条消息属于哪个子项目。只输出项目名（如 my-project）或 UNKNOWN。`;
 }
 
 /**

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -22,6 +22,11 @@ import { buildCustomProvider } from "./providers.ts";
 import { collectTaskLog, type CollectInput } from "./logging/collect.ts";
 import type { Recipient } from "./push/types.ts";
 import type { ModelCacheStats, TaskLog } from "./logging/types.ts";
+import {
+	formatRecentTurns,
+	loadRecentTurns,
+	type ConversationTurn,
+} from "./conversation/store.ts";
 import { markModelCache, markAgentStart, markAgentEnd, stats } from "./monitor/stats.ts";
 
 const models = createModels();
@@ -80,6 +85,10 @@ export interface RunLogContext {
 	recipient?: Recipient;
 	/** Inbound images (decoded bytes) to feed the model as vision input AND persist under the target subproject. */
 	inboundImages?: InboundImage[];
+	/** Fixed conversation session key for IM messages; absent for scheduler / CLI / self-heal. */
+	sessionKey?: string;
+	/** Preloaded recent turns (used by tests); when absent, the runner loads them from the store. */
+	recentTurns?: ConversationTurn[];
 }
 
 export interface TaskResult {
@@ -91,6 +100,8 @@ export interface TaskResult {
 	mutated: boolean;
 	/** Collected task log; the dispatcher overrides `status` then appends it (undefined only on early throw). */
 	log?: TaskLog;
+	/** Persisted inbound-image relative paths, used by the dispatcher when recording the visible turn. */
+	conversationImageRefs?: string[];
 }
 
 const IMAGE_REF_RE = /!\[[^\]]*\]\(([^)]*)\)/g;
@@ -205,6 +216,7 @@ async function routeProject(
 	includeScheduler: boolean,
 	images?: ImageContent[],
 	hasImages = false,
+	recentTurns: readonly ConversationTurn[] = [],
 ): Promise<{ project: string | null; usage?: Usage; prompt?: string; candidates: string[] }> {
 	const projects = listProjectDirs();
 	if (projects.length === 0) return { project: null, candidates: [] };
@@ -214,7 +226,7 @@ async function routeProject(
 	// single-project shortcut above intentionally ignores it (the schedule tool stays available
 	// in any execution context, so single-project setups still work).
 	const candidates = includeScheduler ? [...projects, SCHEDULER_VIRTUAL_PROJECT] : projects;
-	const prompt = buildRoutePrompt(userMessage, includeScheduler, hasImages);
+	const prompt = buildRoutePrompt(userMessage, includeScheduler, hasImages, recentTurns);
 	const agent = new Agent({
 		initialState: {
 			systemPrompt: prompt,
@@ -281,6 +293,15 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 	const ctx: RunLogContext = logCtx ?? { taskId: randomUUID(), source: "cli", phase: "execute" };
 	const startedAt = Date.now();
 	const inboundImages = ctx.inboundImages ?? [];
+	const recentTurns =
+		ctx.recentTurns !== undefined
+			? ctx.recentTurns
+			: CONFIG.conversationContextEnabled &&
+					ctx.phase === "execute" &&
+					ctx.source !== "scheduler" &&
+					ctx.sessionKey
+				? loadRecentTurns(ctx.sessionKey, CONFIG.conversationContextTurns)
+				: [];
 	// Base64-encode each inbound image exactly once and reuse it for routing + execution.
 	const imagesContent = toImageContent(inboundImages);
 	const model = resolveModel();
@@ -327,6 +348,7 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 			ctx.source !== "scheduler",
 			imagesContent,
 			inboundImages.length > 0,
+			recentTurns,
 		);
 		project = routed.project;
 		routingUsage = routed.usage;
@@ -373,8 +395,12 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 		: "";
 	const execText = `${userMessage}${attachmentNote}`.trim();
 
-	// Phase 2: execution
-	const systemPrompt = loadSystemPrompt(project);
+	// Phase 2: execution. Recent visible turns are injected through the system prompt rather
+	// than reconstructed as Agent messages, avoiding internal tool-call metadata.
+	const historyBlock = formatRecentTurns(recentTurns);
+	const systemPrompt = historyBlock
+		? `${loadSystemPrompt(project)}\n\n# 最近对话\n${historyBlock}\n\n以上是最近若干轮用户可见对话。当前消息如果明显是新的独立任务，请忽略旧历史并按新任务处理；如果它是上一轮任务的确认、补充或纠正，请结合历史继续处理。无法确定时向用户确认。`
+		: loadSystemPrompt(project);
 	// Flag set when the tool-turn cap is hit and the run is hard-stopped; used after prompt() to recognize it and return the fallback copy.
 	let toolTurnCapHit = false;
 	const agent = new Agent({
@@ -497,5 +523,5 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 		modelCache: snapshotModelCache(),
 	});
 
-	return { text, images, mutated, log };
+	return { text, images, mutated, log, conversationImageRefs: savedPaths };
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -25,6 +25,7 @@ import type { ModelCacheStats, TaskLog } from "./logging/types.ts";
 import {
 	formatRecentTurns,
 	loadRecentTurns,
+	shouldLoadRecentTurns,
 	type ConversationTurn,
 } from "./conversation/store.ts";
 import { markModelCache, markAgentStart, markAgentEnd, stats } from "./monitor/stats.ts";
@@ -87,8 +88,6 @@ export interface RunLogContext {
 	inboundImages?: InboundImage[];
 	/** Fixed conversation session key for IM messages; absent for scheduler / CLI / self-heal. */
 	sessionKey?: string;
-	/** Preloaded recent turns (used by tests); when absent, the runner loads them from the store. */
-	recentTurns?: ConversationTurn[];
 }
 
 export interface TaskResult {
@@ -100,8 +99,8 @@ export interface TaskResult {
 	mutated: boolean;
 	/** Collected task log; the dispatcher overrides `status` then appends it (undefined only on early throw). */
 	log?: TaskLog;
-	/** Persisted inbound-image relative paths, used by the dispatcher when recording the visible turn. */
-	conversationImageRefs?: string[];
+	/** False for deterministic short-circuit replies that should not consume a conversation slot. */
+	recordConversationTurn?: boolean;
 }
 
 const IMAGE_REF_RE = /!\[[^\]]*\]\(([^)]*)\)/g;
@@ -293,15 +292,14 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 	const ctx: RunLogContext = logCtx ?? { taskId: randomUUID(), source: "cli", phase: "execute" };
 	const startedAt = Date.now();
 	const inboundImages = ctx.inboundImages ?? [];
-	const recentTurns =
-		ctx.recentTurns !== undefined
-			? ctx.recentTurns
-			: CONFIG.conversationContextEnabled &&
-					ctx.phase === "execute" &&
-					ctx.source !== "scheduler" &&
-					ctx.sessionKey
-				? loadRecentTurns(ctx.sessionKey, CONFIG.conversationContextTurns)
-				: [];
+	const recentTurns = shouldLoadRecentTurns({
+		enabled: CONFIG.conversationContextEnabled,
+		phase: ctx.phase,
+		source: ctx.source,
+		sessionKey: ctx.sessionKey,
+	})
+		? loadRecentTurns(ctx.sessionKey!, CONFIG.conversationContextTurns)
+		: [];
 	// Base64-encode each inbound image exactly once and reuse it for routing + execution.
 	const imagesContent = toImageContent(inboundImages);
 	const model = resolveModel();
@@ -313,6 +311,7 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 			images: [],
 			mutated: false,
 			log: buildMinimalLog({ ctx, startedAt, endedAt: Date.now(), userMessage, replyText, project: null }),
+			recordConversationTurn: false,
 		};
 	}
 
@@ -327,6 +326,7 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 			images: [],
 			mutated: false,
 			log: buildMinimalLog({ ctx, startedAt, endedAt: Date.now(), userMessage, replyText, project: null }),
+			recordConversationTurn: false,
 		};
 	}
 
@@ -523,5 +523,5 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 		modelCache: snapshotModelCache(),
 	});
 
-	return { text, images, mutated, log, conversationImageRefs: savedPaths };
+	return { text, images, mutated, log };
 }


### PR DESCRIPTION
## Summary

- Add `CONVERSATION_CONTEXT_MAX_CHARS` and drop oldest turns first at the whole-window cap.
- Remove unused `imageRefs` from the shared conversation store.
- Stop recording greeting and no-data short-circuit replies in shared history.
- Add Telegram and Feishu sender allowlists.
- Separate injected turns with blank lines and `---`; fsync the temp file before rename.
- Store clean auto-fixed replies and original user text only.
- Remove dead `recentTurns` test hook; add focused tests.

## Verification

- `npm run typecheck` passes.
- `npm test` passes: 137/137.
- `git diff --check` is clean.