### PR TITLE
feat: multi-project routing with serial execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"restart": "bash scripts/botlerctl.sh restart",
 		"init": "tsx src/init.ts",
 		"typecheck": "tsc --noEmit",
-		"test": "tsx --test src/scheduler/cron.test.ts src/scheduler/store.test.ts src/scheduler/history.test.ts src/logging/store.test.ts src/monitor/stats.test.ts src/greeting.test.ts src/channels/allowlist.test.ts src/channels/wechat/aes-ecb.test.ts src/channels/wechat/download.test.ts src/channels/wechat/image-batch.test.ts src/conversation/store.test.ts src/tools/clear-conversation.test.ts src/runner/decisions.test.ts",
+		"test": "tsx --test src/scheduler/cron.test.ts src/scheduler/store.test.ts src/scheduler/history.test.ts src/logging/store.test.ts src/monitor/stats.test.ts src/greeting.test.ts src/channels/allowlist.test.ts src/channels/wechat/aes-ecb.test.ts src/channels/wechat/download.test.ts src/channels/wechat/image-batch.test.ts src/conversation/store.test.ts src/tools/clear-conversation.test.ts src/tools/paths.test.ts src/safety/validate.test.ts src/safety/git.test.ts src/runner/decisions.test.ts",
 		"webui": "tsx src/webui/server.ts",
 		"cli": "tsx src/index.ts"
 	},

--- a/src/conversation/store.test.ts
+++ b/src/conversation/store.test.ts
@@ -53,6 +53,34 @@ test("appendTurn preserves a null project for unknown-project turns", () => {
 	assert.equal(store.loadRecentTurns(store.IM_SESSION_KEY, 5)[0].project, null);
 });
 
+test("appendTurn round-trips a multi-project turn with a null legacy project", () => {
+	store.clearSession(store.IM_SESSION_KEY);
+	store.appendTurn(
+		store.IM_SESSION_KEY,
+		{ ts: 1, project: null, projects: ["cook", "vocab"], user: "u", assistant: "a" },
+		5,
+	);
+	const [t] = store.loadRecentTurns(store.IM_SESSION_KEY, 5);
+	assert.deepEqual(t.projects, ["cook", "vocab"]);
+	assert.equal(t.project, null);
+});
+
+test("normalizeTurn falls back to [project] for old single-project data", () => {
+	store.clearSession(store.IM_SESSION_KEY);
+	store.appendTurn(store.IM_SESSION_KEY, turn(1, "cook"), 5);
+	const [t] = store.loadRecentTurns(store.IM_SESSION_KEY, 5);
+	assert.deepEqual(t.projects, ["cook"]);
+	assert.equal(t.project, "cook");
+});
+
+test("formatRecentTurns renders joined project labels for multi-project turns", () => {
+	const turns = [{ ts: 1, project: null, projects: ["cook", "vocab"], user: "u", assistant: "a" }];
+	assert.equal(
+		store.formatRecentTurns(turns, { includeProject: true }),
+		"（项目：cook, vocab）用户：u\nBot：a",
+	);
+});
+
 test("appendTurn truncates user and assistant messages to the configured max chars", () => {
 	store.clearSession(store.IM_SESSION_KEY);
 	store.appendTurn(

--- a/src/conversation/store.ts
+++ b/src/conversation/store.ts
@@ -16,8 +16,10 @@ export const IM_SESSION_KEY = "im";
 export interface ConversationTurn {
 	/** Epoch ms of the turn's start. */
 	ts: number;
-	/** Routed data subproject; null when the reply did not target a project. */
+	/** Routed data subproject; null when the reply did not target a project (legacy display field derived from `projects`). */
 	project: string | null;
+	/** Selected data subprojects (ordered); optional to tolerate old persisted turns. */
+	projects?: string[];
 	/** User-visible input text. */
 	user: string;
 	/** User-visible final Bot reply text. */
@@ -35,6 +37,13 @@ function normalizeProject(value: unknown): string | null {
 	return typeof value === "string" && value ? value : null;
 }
 
+function normalizeProjects(value: unknown): string[] | undefined {
+	if (!Array.isArray(value)) return undefined;
+	const out: string[] = [];
+	for (const v of value) if (typeof v === "string" && v) out.push(v);
+	return out;
+}
+
 function normalizeTurn(value: unknown): ConversationTurn | null {
 	if (!value || typeof value !== "object") return null;
 	const raw = value as Record<string, unknown>;
@@ -43,9 +52,14 @@ function normalizeTurn(value: unknown): ConversationTurn | null {
 	const user = typeof raw.user === "string" ? raw.user.slice(0, CONFIG.conversationTurnMaxChars) : "";
 	const assistant = typeof raw.assistant === "string" ? raw.assistant.slice(0, CONFIG.conversationTurnMaxChars) : "";
 	if (!user && !assistant) return null;
+	const project = normalizeProject(raw.project);
+	const rawProjects = normalizeProjects(raw.projects);
+	// Prefer a non-empty plural set; fall back to [project] for old singular data (or [] when none).
+	const projects = rawProjects && rawProjects.length ? rawProjects : project ? [project] : [];
 	return {
 		ts,
-		project: normalizeProject(raw.project),
+		project,
+		projects,
 		user,
 		assistant,
 	};
@@ -126,7 +140,8 @@ export function formatRecentTurns(
 	if (!Number.isFinite(maxChars) || maxChars <= 0) return "";
 	const separator = "\n\n---\n\n";
 	const rendered = turns.map((turn) => {
-		const project = opts.includeProject && turn.project ? `（项目：${turn.project}）` : "";
+		const label = turn.projects?.length ? turn.projects.join(", ") : turn.project;
+		const project = opts.includeProject && label ? `（项目：${label}）` : "";
 		return `${project}用户：${turn.user}\nBot：${turn.assistant}`;
 	});
 	// Keep the newest turns within the whole-window cap, dropping the oldest turns first.

--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -26,6 +26,8 @@ export interface DispatchOptions {
 	source?: string;
 	/** Optional routing hint (a valid data subproject). Scheduler entries use it to skip the routing LLM call. */
 	projectHint?: string;
+	/** Optional plural routing hint (valid data subproject names); used by the self-heal retry. */
+	projectsHint?: string[];
 	/** Optional recipient: the sender of this message. Tools like schedule inject it as the push target. */
 	recipient?: Recipient;
 	/**
@@ -81,6 +83,7 @@ function appendVisibleTurn(
 		{
 			ts: log.startedAt,
 			project: log.project,
+			projects: log.projects,
 			// The model sees an additional image-persisted note appended by the framework;
 			// history deliberately stores only the original user text, not that transport note.
 			user: message,
@@ -117,6 +120,7 @@ function minimalLog(opts: {
 		provider: CONFIG.provider,
 		model: CONFIG.model,
 		project: null,
+		projects: [],
 		status: opts.status,
 		startedAt: opts.startedAt,
 		endedAt: Date.now(),
@@ -198,20 +202,20 @@ export async function dispatch(message: string, opts: DispatchOptions = {}): Pro
 			}
 
 			if (!result.mutated) {
-				// Read-only task (query) — or unrouted/no-project (project === null).
-				log.status = log.project === null ? "unknown-project" : "success";
+				// Read-only task (query) — or unrouted/no-project (empty selected set).
+				log.status = log.projects && log.projects.length === 0 ? "unknown-project" : "success";
 				log.replyText = result.text;
 				appendTaskLog(log);
 				finalStatus = log.status;
 				return out(result.text, result.images, log.status);
 			}
 
-			let validation = validateState();
+			let validation = validateState(log.projects);
 			if (!validation.ok) {
 				// A fresh Agent reads the file and self-heals in place.
 				console.log(`[dispatch] Validation failed; self-heal retry: ${validation.fix}`);
-				const heal = await runTask(validation.fix!, { taskId, source, phase: "self-heal" });
-				validation = validateState();
+				const heal = await runTask(validation.fix!, { taskId, source, phase: "self-heal", projectsHint: log.projects });
+				validation = validateState(log.projects);
 				if (!validation.ok) {
 					const errText = `⚠️ Could not save safely; please check the data: ${validation.fix ?? ""}`;
 					log.status = "validation-failed";
@@ -225,7 +229,7 @@ export async function dispatch(message: string, opts: DispatchOptions = {}): Pro
 					finalStatus = "validation-failed";
 					return out(errText, [], "validation-failed");
 				}
-				commitIfChanged(`agent: ${truncate(message)}`);
+				commitIfChanged(`agent: ${truncate(message)}`, log.projects);
 				const finalText = `${result.text}\n\n(auto-fixed and saved)`;
 				log.status = "auto-fixed";
 				log.replyText = finalText;
@@ -238,7 +242,7 @@ export async function dispatch(message: string, opts: DispatchOptions = {}): Pro
 				return out(finalText, result.images, "auto-fixed");
 			}
 
-			commitIfChanged(`agent: ${truncate(message)}`);
+			commitIfChanged(`agent: ${truncate(message)}`, log.projects);
 			log.status = "success";
 			log.replyText = result.text;
 			appendTaskLog(log);

--- a/src/logging/collect.ts
+++ b/src/logging/collect.ts
@@ -15,6 +15,7 @@ import type {
 	TokenUsageLog,
 	ToolCallLog,
 } from "./types.ts";
+import { legacyProject } from "./utils.ts";
 
 /** Max characters for result text / thinking / conversation text (user msg & final reply are not truncated). */
 const TEXT_MAX = 2000;
@@ -54,7 +55,8 @@ export interface CollectInput {
 	source: string;
 	provider: string;
 	model: string;
-	project: string | null;
+	/** Selected data subprojects (ordered, deduplicated); empty = not routed. */
+	projects: string[];
 	startedAt: number;
 	endedAt: number;
 	userMessage: string;
@@ -81,7 +83,7 @@ export function collectTaskLog(input: CollectInput): TaskLog {
 		source,
 		provider,
 		model,
-		project,
+		projects,
 		startedAt,
 		endedAt,
 		userMessage,
@@ -196,7 +198,8 @@ export function collectTaskLog(input: CollectInput): TaskLog {
 		source,
 		provider,
 		model,
-		project,
+		project: legacyProject(projects),
+		projects,
 		status: "success",
 		startedAt,
 		endedAt,

--- a/src/logging/store.test.ts
+++ b/src/logging/store.test.ts
@@ -1,7 +1,18 @@
-import test from "node:test";
+import { before, test } from "node:test";
 import assert from "node:assert/strict";
-import { filterAndPageLogs, matchesLogQuery, scheduleIdFromTaskId } from "./store.ts";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import type { TaskLog } from "./types.ts";
+
+let store: typeof import("./store.ts");
+
+before(async () => {
+	const tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "botler-logstore-")));
+	process.env.BOTLER_CONFIG_DIR = tmp;
+	process.env.BOTLER_LOG_DIR = path.join(tmp, "logs");
+	store = await import("./store.ts");
+});
 
 function makeLog(overrides: Partial<TaskLog> = {}): TaskLog {
 	return {
@@ -30,28 +41,48 @@ function makeLog(overrides: Partial<TaskLog> = {}): TaskLog {
 }
 
 test("scheduleIdFromTaskId extracts a normal schedule id", () => {
-	assert.equal(scheduleIdFromTaskId("schedule:drink-water:1720000000000"), "drink-water");
+	assert.equal(store.scheduleIdFromTaskId("schedule:drink-water:1720000000000"), "drink-water");
 });
 
 test("scheduleIdFromTaskId supports colon in the schedule id", () => {
-	assert.equal(scheduleIdFromTaskId("schedule:foo:bar:1720000000000"), "foo:bar");
+	assert.equal(store.scheduleIdFromTaskId("schedule:foo:bar:1720000000000"), "foo:bar");
 });
 
 test("scheduleIdFromTaskId ignores non-scheduler task ids", () => {
-	assert.equal(scheduleIdFromTaskId("telegram:123:456"), undefined);
-	assert.equal(scheduleIdFromTaskId("random-task-id"), undefined);
+	assert.equal(store.scheduleIdFromTaskId("telegram:123:456"), undefined);
+	assert.equal(store.scheduleIdFromTaskId("random-task-id"), undefined);
 });
 
 test("matchesLogQuery filters scheduler logs by scheduleId", () => {
 	const q = { source: "scheduler", scheduleId: "foo:bar" };
-	assert.equal(matchesLogQuery(makeLog({ taskId: "schedule:foo:bar:1720000000000" }), q), true);
-	assert.equal(matchesLogQuery(makeLog({ taskId: "schedule:other:1720000000000" }), q), false);
+	assert.equal(store.matchesLogQuery(makeLog({ taskId: "schedule:foo:bar:1720000000000" }), q), true);
+	assert.equal(store.matchesLogQuery(makeLog({ taskId: "schedule:other:1720000000000" }), q), false);
 });
 
 test("matchesLogQuery filters by phase", () => {
 	const q = { source: "scheduler", scheduleId: "foo", phase: "execute" as const };
-	assert.equal(matchesLogQuery(makeLog({ phase: "execute" }), q), true);
-	assert.equal(matchesLogQuery(makeLog({ phase: "self-heal" }), q), false);
+	assert.equal(store.matchesLogQuery(makeLog({ phase: "execute" }), q), true);
+	assert.equal(store.matchesLogQuery(makeLog({ phase: "self-heal" }), q), false);
+});
+
+test("matchesLogQuery matches a multi-project log by any selected project", () => {
+	const log = makeLog({ project: null, projects: ["cook", "vocab"] });
+	assert.equal(store.matchesLogQuery(log, { project: "cook" }), true);
+	assert.equal(store.matchesLogQuery(log, { project: "vocab" }), true);
+	assert.equal(store.matchesLogQuery(log, { project: "notes" }), false);
+});
+
+test("matchesLogQuery falls back to the legacy project for old single-project logs", () => {
+	const log = makeLog({ project: "cook" });
+	assert.equal(store.matchesLogQuery(log, { project: "cook" }), true);
+	assert.equal(store.matchesLogQuery(log, { project: "vocab" }), false);
+});
+
+test("matchesLogQuery full-text search hits on a selected project name", () => {
+	const log = makeLog({ project: null, projects: ["cook", "vocab"], userMessage: "add", replyText: "done" });
+	assert.equal(store.matchesLogQuery(log, { q: "cook" }), true);
+	assert.equal(store.matchesLogQuery(log, { q: "vocab" }), true);
+	assert.equal(store.matchesLogQuery(log, { q: "nothing" }), false);
 });
 
 test("filterAndPageLogs filters by scheduleId and handles ids containing a colon", () => {
@@ -61,7 +92,7 @@ test("filterAndPageLogs filters by scheduleId and handles ids containing a colon
 		makeLog({ taskId: "schedule:other:1720000002000", startedAt: 1720000002000 }),
 	];
 
-	const page = filterAndPageLogs(logs, {
+	const page = store.filterAndPageLogs(logs, {
 		source: "scheduler",
 		scheduleId: "foo:bar",
 		limit: 1,
@@ -80,7 +111,7 @@ test("filterAndPageLogs pages past the first match without changing total", () =
 		makeLog({ taskId: "schedule:foo:1720000001000", startedAt: 1720000001000 }),
 	];
 
-	const page = filterAndPageLogs(logs, {
+	const page = store.filterAndPageLogs(logs, {
 		source: "scheduler",
 		scheduleId: "foo",
 		limit: 1,
@@ -90,4 +121,29 @@ test("filterAndPageLogs pages past the first match without changing total", () =
 	assert.equal(page.total, 3);
 	assert.equal(page.logs.length, 1);
 	assert.equal(page.logs[0].taskId, "schedule:foo:1720000002000");
+});
+
+test("summary counts a multi-project log under every selected project", () => {
+	store.appendTaskLog(
+		makeLog({
+			id: "sum-multi",
+			taskId: "telegram:summulti:1",
+			source: "telegram",
+			project: null,
+			projects: ["sumcook", "sumvocab"],
+		}),
+	);
+	store.appendTaskLog(
+		makeLog({
+			id: "sum-single",
+			taskId: "telegram:sumsingle:1",
+			source: "telegram",
+			project: "sumcook",
+			projects: ["sumcook"],
+		}),
+	);
+
+	const s = store.summary();
+	assert.equal(s.byProject["sumcook"], 2);
+	assert.equal(s.byProject["sumvocab"], 1);
 });

--- a/src/logging/store.ts
+++ b/src/logging/store.ts
@@ -64,16 +64,22 @@ export function scheduleIdFromTaskId(taskId: string): string | undefined {
 }
 
 export function matchesLogQuery(log: TaskLog, q: LogQuery): boolean {
-	if (q.project && log.project !== q.project) return false;
+	if (q.project) {
+		const matches = log.projects?.length
+			? log.projects.includes(q.project)
+			: log.project === q.project;
+		if (!matches) return false;
+	}
 	if (q.source && log.source !== q.source) return false;
 	if (q.phase && log.phase !== q.phase) return false;
 	if (q.scheduleId && scheduleIdFromTaskId(log.taskId) !== q.scheduleId) return false;
 	if (q.q) {
 		const needle = q.q.toLowerCase();
+		const projectText = [log.project, ...(log.projects ?? [])].filter(Boolean).join(" ").toLowerCase();
 		if (
 			!log.userMessage.toLowerCase().includes(needle) &&
 			!log.replyText.toLowerCase().includes(needle) &&
-			!(log.project ?? "").toLowerCase().includes(needle)
+			!projectText.includes(needle)
 		) {
 			return false;
 		}
@@ -190,8 +196,8 @@ export function summary(): TaskSummary {
 
 	for (const l of all) {
 		byStatus[l.status] = (byStatus[l.status] ?? 0) + 1;
-		const proj = l.project ?? "(none)";
-		byProject[proj] = (byProject[proj] ?? 0) + 1;
+		const names = l.projects?.length ? l.projects : l.project ? [l.project] : ["(none)"];
+		for (const proj of names) byProject[proj] = (byProject[proj] ?? 0) + 1;
 		bySource[l.source] = (bySource[l.source] ?? 0) + 1;
 		token.input += l.usage.input;
 		token.output += l.usage.output;
@@ -283,6 +289,9 @@ function stepMs(g: Granularity): number {
  * Every group gets the same continuous bucket array, so the frontend can align its X axis
  * without handling missing buckets. No grouping returns at least one "(all)" group (empty
  * bucket sequence) so the UI never renders a blank state.
+ *
+ * Note: grouping by "project" counts a multi-project log once per selected project, so token
+ * totals summed across project groups can exceed the ungrouped ("(all)") total.
  */
 export function tokenTimeSeries(q: TokenTimeQuery = {}): TokenTimeSeries {
 	const g = q.granularity ?? "day";
@@ -310,8 +319,19 @@ export function tokenTimeSeries(q: TokenTimeQuery = {}): TokenTimeSeries {
 		costUsd: 0,
 	}));
 
-	const groupKey = (l: TaskLog): string =>
-		q.groupBy === "project" ? (l.project ?? "(none)") : q.groupBy === "source" ? l.source : "(all)";
+	// A multi-project log expands into one bucket increment per selected project (else it would
+	// collapse into "(none)"). Note: when `groupBy === "project"` this counts a multi-project
+	// log's tokens once per project, so the per-project totals can exceed the ungrouped total.
+	const groupKeys = (l: TaskLog): string[] =>
+		q.groupBy === "project"
+			? l.projects?.length
+				? l.projects
+				: l.project
+					? [l.project]
+					: ["(none)"]
+			: q.groupBy === "source"
+				? [l.source]
+				: ["(all)"];
 
 	const groups = new Map<string, TokenBucket[]>();
 	const groupOf = (k: string): TokenBucket[] => {
@@ -330,14 +350,16 @@ export function tokenTimeSeries(q: TokenTimeQuery = {}): TokenTimeSeries {
 		if (l.startedAt < lo || l.startedAt > hi) continue;
 		const idx = Math.floor((l.startedAt - first) / step);
 		if (idx < 0 || idx >= buckets.length) continue;
-		const b = groupOf(groupKey(l))[idx];
-		b.tasks += 1;
-		b.input += l.usage.input;
-		b.output += l.usage.output;
-		b.cacheRead += l.usage.cacheRead;
-		b.cacheWrite += l.usage.cacheWrite;
-		b.total += l.usage.total;
-		b.costUsd += l.usage.costUsd;
+		for (const k of groupKeys(l)) {
+			const b = groupOf(k)[idx];
+			b.tasks += 1;
+			b.input += l.usage.input;
+			b.output += l.usage.output;
+			b.cacheRead += l.usage.cacheRead;
+			b.cacheWrite += l.usage.cacheWrite;
+			b.total += l.usage.total;
+			b.costUsd += l.usage.costUsd;
+		}
 	}
 
 	return {

--- a/src/logging/types.ts
+++ b/src/logging/types.ts
@@ -99,8 +99,10 @@ export interface TaskLog {
 	source: string;
 	provider: string;
 	model: string;
-	/** Routed subproject; null = not routed / no project. */
+	/** Routed subproject; null = not routed / no project (legacy display field derived from `projects`). */
 	project: string | null;
+	/** Selected data subprojects (ordered, deduplicated); empty = not routed. Optional to tolerate old JSONL entries. */
+	projects?: string[];
 	status: TaskStatus;
 	startedAt: number;
 	endedAt: number;

--- a/src/logging/utils.ts
+++ b/src/logging/utils.ts
@@ -1,0 +1,11 @@
+import { SCHEDULER_VIRTUAL_PROJECT } from "../prompts/system-prompt.ts";
+
+/**
+ * Legacy singular display field derived from the selected set: non-null only when exactly one
+ * real data project was selected. A multi-project log therefore has `project === null` but a
+ * non-empty `projects`. The virtual `__scheduler__` project is never a data project, so it
+ * also yields null.
+ */
+export function legacyProject(projects: readonly string[]): string | null {
+	return projects.length === 1 && projects[0] !== SCHEDULER_VIRTUAL_PROJECT ? projects[0] : null;
+}

--- a/src/prompts/system-prompt.ts
+++ b/src/prompts/system-prompt.ts
@@ -21,7 +21,7 @@ export const DEFAULT_SYSTEM_PROMPT = `你是运行在个人数据目录下的轻
 __PROJECT_CONTEXT__
 
 # 工作原则
-- 你已被路由到上面的数据子项目，直接按该项目约定完成任务即可；不要操作其他子项目。
+- 你只能操作下面“当前选中数据子项目与约定”列出的项目；可以按任务需要依次操作其中多个项目，绝不能操作未列出的数据子项目。
 - 修改文件前先用 read 读取现有内容，在上下文中修改后整体写回（write 接受数据结构本身，不是 JSON 文本）。
 - 必须保持 JSON 合法、字段类型一致（数字就是数字，字符串就是字符串）。
 - 写完后用平实的中文向用户汇报结果，给出关键数字。
@@ -161,6 +161,11 @@ function projectContext(name: string): string {
 	return `## ${name}/\n（约定文档内容${truncated ? "，已截断" : ""}）\n${truncated ? content.slice(0, RULE_MAX_CHARS) : content}`;
 }
 
+/** Concatenate the convention docs of several projects in selection order (used in the execution phase). */
+function projectsContext(names: readonly string[]): string {
+	return names.map((n) => projectContext(n)).join("\n\n");
+}
+
 /**
  * Virtual "project" context for schedule management requests (no data subproject involved).
  * Routed to when the message is about creating/managing scheduled tasks.
@@ -213,24 +218,28 @@ export function buildRoutePrompt(
 	const resetInstruction = allowResetContext
 		? `\n如果用户明确要求清空 / 忽略 / 重置之前的上下文（例如「新任务」「忽略上文」「重置上下文」，或等价表达），只输出 ${RESET_CONTEXT_DECISION}。若用户的新任务还带有具体的数据操作，则仍输出对应项目，不要输出 ${RESET_CONTEXT_DECISION}。\n`
 		: "";
+	const jsonInstruction = `只输出 JSON：{"projects":["项目名"],"attachmentProject":"项目名或null"}。
+projects 必须是一个或多个给定候选项目名（按需要依次列出）；无法确定时只输出 UNKNOWN。
+如果选择 ${SCHEDULER_VIRTUAL_PROJECT}，projects 必须只能是 ["${SCHEDULER_VIRTUAL_PROJECT}"]，且 attachmentProject 必须为 null。
+有图片时 attachmentProject 必须是 projects 中唯一一个用于保存原图的项目；无图片时写 null。`;
 	const outputCandidates = allowResetContext
-		? `只输出项目名（如 my-project）、${RESET_CONTEXT_DECISION} 或 UNKNOWN。`
-		: "只输出项目名（如 my-project）或 UNKNOWN。";
-	return `你是路由助手，负责判断用户消息要操作哪个数据子项目。只输出一个项目名（不含斜杠），无法确定时只输出 UNKNOWN。不要使用任何工具。
+		? `${jsonInstruction}\n若用户明确要求清空 / 忽略 / 重置之前的上下文，只输出 ${RESET_CONTEXT_DECISION}。`
+		: jsonInstruction;
+	return `你是路由助手，负责判断用户消息要操作哪个（或哪几个）数据子项目。只输出 JSON（不要输出解释文字），不要使用任何工具。
 
 数据根目录下的子项目：
 ${listProjectSummaries()}${schedulerLine}${historyBlock}用户消息：${userMessage}
-${imageLine}${historyInstruction}${resetInstruction}判断这条消息属于哪个子项目。${outputCandidates}`;
+${imageLine}${historyInstruction}${resetInstruction}判断这条消息属于哪个（或哪几个）子项目。${outputCandidates}`;
 }
 
 /**
  * Load the execution-phase system prompt (phase 2):
  * 1. ~/.botler-agent/system-prompt.md exists → use the externalized one; otherwise fall back to the built-in default;
- * 2. for a real data subproject, concatenate only that project's convention doc in full, by projectName;
- *    for the virtual `__scheduler__` project, use the schedule-management context instead (no data rules);
+ * 2. for real data subprojects, concatenate the convention docs of every selected project, in selection order;
+ *    for the virtual `__scheduler__` project (always sole), use the schedule-management context instead (no data rules);
  * 3. uniformly replace placeholders.
  */
-export function loadSystemPrompt(projectName?: string): string {
+export function loadSystemPrompt(projectNames?: readonly string[]): string {
 	let base = DEFAULT_SYSTEM_PROMPT;
 	const userPrompt = join(USER_CONFIG_DIR, "system-prompt.md");
 	if (existsSync(userPrompt)) {
@@ -241,11 +250,11 @@ export function loadSystemPrompt(projectName?: string): string {
 		}
 	}
 	const ctx =
-		projectName === SCHEDULER_VIRTUAL_PROJECT
-			? schedulerContext()
-			: projectName
-				? projectContext(projectName)
-				: listProjectSummaries();
+		!projectNames || projectNames.length === 0
+			? listProjectSummaries()
+			: projectNames.length === 1 && projectNames[0] === SCHEDULER_VIRTUAL_PROJECT
+				? schedulerContext()
+				: projectsContext(projectNames);
 	return base
 		.replaceAll("__DATA_ROOT__", CONFIG.dataRoot)
 		.replaceAll("__PROJECTS__", listProjects())

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -33,6 +33,7 @@ import { buildCustomProvider } from "./providers.ts";
 import { collectTaskLog, type CollectInput } from "./logging/collect.ts";
 import type { Recipient } from "./push/types.ts";
 import type { ModelCacheStats, TaskLog } from "./logging/types.ts";
+import { legacyProject } from "./logging/utils.ts";
 import {
 	formatRecentTurns,
 	loadRecentTurns,
@@ -94,6 +95,8 @@ export interface RunLogContext {
 	phase: "execute" | "self-heal";
 	/** Optional routing hint (a valid data subproject name) — skips the routing LLM call. */
 	projectHint?: string;
+	/** Optional plural routing hint (valid data subproject names) — used by the self-heal retry to avoid re-routing ambiguously. */
+	projectsHint?: string[];
 	/** Optional recipient (the message sender); injected into the task context for tools like schedule. */
 	recipient?: Recipient;
 	/** Inbound images (decoded bytes) to feed the model as vision input AND persist under the target subproject. */
@@ -121,13 +124,14 @@ const IMAGE_EXT_RE = /\.(png|jpe?g|gif|webp|bmp)$/i;
 /**
  * Split the reply into text + image references (markdown `![alt](path)`).
  *
- * Local paths go through safePath (DATA_ROOT allowlist + symlink escape check) and must be an
- * existing image file — the agent supplies the path, but the framework decides whether it is
- * allowed, so a hallucinated path cannot leak an arbitrary file. Invalid refs are dropped
- * silently: the text reply still gets through. Image markdown is always stripped from the text,
- * so channels that cannot render it (telegram / CLI) don't show raw markdown.
+ * Local paths go through safePath (DATA_ROOT allowlist + symlink escape check + task-local
+ * selected-project subset) and must be an existing image file — the agent supplies the path, but
+ * the framework decides whether it is allowed, so a hallucinated path cannot leak an arbitrary
+ * file. Invalid refs are dropped silently: the text reply still gets through. Image markdown is
+ * always stripped from the text, so channels that cannot render it (telegram / CLI) don't show
+ * raw markdown.
  */
-function extractImages(text: string): { text: string; images: string[] } {
+function extractImages(text: string, projects: readonly string[]): { text: string; images: string[] } {
 	const images: string[] = [];
 	for (const m of text.matchAll(IMAGE_REF_RE)) {
 		const ref = (m[1] ?? "").trim();
@@ -138,7 +142,7 @@ function extractImages(text: string): { text: string; images: string[] } {
 		}
 		if (!IMAGE_EXT_RE.test(ref)) continue;
 		try {
-			const abs = safePath(ref);
+			const abs = safePath(ref, { projects });
 			if (statSync(abs).isFile() && !images.includes(abs)) images.push(abs);
 		} catch {
 			// Out of bounds / missing / unreadable: skip this image, keep the reply text
@@ -212,10 +216,12 @@ async function routeProject(
 	hasImages = false,
 	recentTurns: readonly ConversationTurn[] = [],
 	allowResetContext = false,
-): Promise<{ project: string | null; resetContext: boolean; usage?: Usage; prompt?: string; candidates: string[] }> {
+): Promise<{ projects: string[]; attachmentProject: string | null; resetContext: boolean; usage?: Usage; prompt?: string; candidates: string[] }> {
 	const projects = listProjectDirs();
-	if (projects.length === 0) return { project: null, resetContext: false, candidates: [] };
-	if (projects.length === 1) return { project: projects[0], resetContext: false, candidates: [...projects] };
+	if (projects.length === 0) return { projects: [], attachmentProject: null, resetContext: false, candidates: [] };
+	if (projects.length === 1) {
+		return { projects: [...projects], attachmentProject: null, resetContext: false, candidates: [...projects] };
+	}
 
 	// The virtual scheduler project is a routing candidate but NOT a data subproject; the
 	// single-project shortcut above intentionally ignores it (the schedule tool stays available
@@ -226,7 +232,7 @@ async function routeProject(
 		initialState: {
 			systemPrompt: prompt,
 			model,
-			tools: [], // Routing phase needs no tools, only outputs the project name
+			tools: [], // Routing phase needs no tools, only outputs the project set
 		},
 		streamFn: models.streamSimple.bind(models),
 	});
@@ -235,7 +241,14 @@ async function routeProject(
 	// Routing state is [user, assistant]; the assistant message carries a single clean usage.
 	const assistant = agent.state.messages[agent.state.messages.length - 1];
 	const usage = assistant && assistant.role === "assistant" ? assistant.usage : undefined;
-	return { project: decision.project, resetContext: decision.resetContext, usage, prompt, candidates };
+	return {
+		projects: decision.projects,
+		attachmentProject: decision.attachmentProject,
+		resetContext: decision.resetContext,
+		usage,
+		prompt,
+		candidates,
+	};
 }
 
 /**
@@ -248,7 +261,7 @@ function buildMinimalLog(opts: {
 	endedAt: number;
 	userMessage: string;
 	replyText: string;
-	project: string | null;
+	projects: string[];
 	routingUsage?: Usage;
 	routing?: { candidates: string[]; decision: string | null; prompt?: string };
 }): TaskLog {
@@ -259,7 +272,7 @@ function buildMinimalLog(opts: {
 		source: opts.ctx.source,
 		provider: CONFIG.provider,
 		model: CONFIG.model,
-		project: opts.project,
+		projects: opts.projects,
 		startedAt: opts.startedAt,
 		endedAt: opts.endedAt,
 		userMessage: opts.userMessage,
@@ -312,7 +325,7 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 			text: replyText,
 			images: [],
 			mutated: false,
-			log: buildMinimalLog({ ctx, startedAt, endedAt: Date.now(), userMessage, replyText, project: null }),
+			log: buildMinimalLog({ ctx, startedAt, endedAt: Date.now(), userMessage, replyText, projects: [] }),
 			recordConversationTurn: false,
 		};
 	}
@@ -327,20 +340,29 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 			text: replyText,
 			images: [],
 			mutated: false,
-			log: buildMinimalLog({ ctx, startedAt, endedAt: Date.now(), userMessage, replyText, project: null }),
+			log: buildMinimalLog({ ctx, startedAt, endedAt: Date.now(), userMessage, replyText, projects: [] }),
 			recordConversationTurn: false,
 		};
 	}
 
 	// Phase 1 (routing): a valid projectHint skips the routing LLM call entirely.
 	const hint = ctx.projectHint;
-	let project: string | null;
+	const hintProjects = ctx.projectsHint;
+	let selectedProjects: string[];
+	let attachmentProject: string | null;
 	let routingUsage: Usage | undefined;
 	let routingPrompt: string | undefined;
 	let routingCandidates: string[];
 	let resetContext = false;
 	if (hint && projects.includes(hint)) {
-		project = hint;
+		selectedProjects = [hint];
+		attachmentProject = null;
+		routingUsage = undefined;
+		routingPrompt = undefined;
+		routingCandidates = [...projects, SCHEDULER_VIRTUAL_PROJECT];
+	} else if (hintProjects && hintProjects.length > 0) {
+		selectedProjects = hintProjects.filter((n) => projects.includes(n));
+		attachmentProject = null;
 		routingUsage = undefined;
 		routingPrompt = undefined;
 		routingCandidates = [...projects, SCHEDULER_VIRTUAL_PROJECT];
@@ -355,7 +377,8 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 			isImSession,
 		);
 		resetContext = routed.resetContext;
-		project = routed.resetContext ? null : routed.project;
+		selectedProjects = routed.resetContext ? [] : routed.projects;
+		attachmentProject = routed.resetContext ? null : routed.attachmentProject;
 		routingUsage = routed.usage;
 		routingPrompt = routed.prompt;
 		routingCandidates = routed.candidates;
@@ -373,14 +396,14 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 				endedAt: Date.now(),
 				userMessage,
 				replyText,
-				project: null,
+				projects: [],
 				routingUsage,
 				routing: { candidates: routingCandidates, decision: RESET_CONTEXT_DECISION, prompt: routingPrompt },
 			}),
 			recordConversationTurn: false,
 		};
 	}
-	if (!project) {
+	if (selectedProjects.length === 0) {
 		const replyText = fallbackUnknownReply(inboundImages.length > 0);
 		return {
 			text: replyText,
@@ -392,24 +415,51 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 				endedAt: Date.now(),
 				userMessage,
 				replyText,
-				project: null,
+				projects: [],
 				routingUsage,
 				routing: { candidates: routingCandidates, decision: null, prompt: routingPrompt },
 			}),
 		};
 	}
 
-	// Persist originals under DATA_ROOT/<project>/photos, then tell the agent where they are.
+	// Inbound images must persist to a single data subproject. If the routing model omitted the
+	// attachment and exactly one real project is selected, default to it (unique owner). Multiple
+	// real projects with no explicit attachment cannot be resolved — never write arbitrarily.
+	const realSelectedProjects = selectedProjects.filter((n) => n !== SCHEDULER_VIRTUAL_PROJECT);
+	if (inboundImages.length > 0 && !attachmentProject) {
+		if (realSelectedProjects.length === 1) {
+			attachmentProject = realSelectedProjects[0];
+		} else if (realSelectedProjects.length > 1) {
+			const replyText = fallbackUnknownReply(true);
+			return {
+				text: replyText,
+				images: [],
+				mutated: false,
+				log: buildMinimalLog({
+					ctx,
+					startedAt,
+					endedAt: Date.now(),
+					userMessage,
+					replyText,
+					projects: selectedProjects,
+					routingUsage,
+					routing: { candidates: routingCandidates, decision: null, prompt: routingPrompt },
+				}),
+			};
+		}
+	}
+
+	// Persist originals under DATA_ROOT/<attachmentProject>/photos, then tell the agent where they are.
 	// Persistence happens only after a subproject is known — unrouted / unknown-project messages
 	// (returned above) never write a photo into DATA_ROOT, and the virtual __scheduler__ project
 	// is not a data subproject (nothing to persist, avoids a spurious warn). The file is written
 	// by the framework (a transport concern), validated through safePath + an image-extension
 	// whitelist; the agent only ever receives the relative path as text to cite in its record.
 	const savedPaths: string[] = [];
-	if (inboundImages.length > 0 && project !== SCHEDULER_VIRTUAL_PROJECT) {
+	if (inboundImages.length > 0 && attachmentProject) {
 		for (const img of inboundImages) {
 			try {
-				savedPaths.push(await persistInboundImage(img, project!));
+				savedPaths.push(await persistInboundImage(img, attachmentProject));
 			} catch (e) {
 				console.warn(`[runner] persist image failed: ${String(e)}`);
 			}
@@ -424,9 +474,9 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 	// than reconstructed as Agent messages, avoiding internal tool-call metadata.
 	const historyBlock = formatRecentTurns(recentTurns);
 	const baseSystemPrompt = historyBlock
-		? `${loadSystemPrompt(project)}\n\n# 最近对话\n${historyBlock}\n\n以上是最近若干轮用户可见对话。当前消息如果明显是新的独立任务，请忽略旧历史并按新任务处理；如果它是上一轮任务的确认、补充或纠正，请结合历史继续处理。无法确定时向用户确认。`
-		: loadSystemPrompt(project);
-	const canControlConversation = isImSession && project !== SCHEDULER_VIRTUAL_PROJECT;
+		? `${loadSystemPrompt(selectedProjects)}\n\n# 最近对话\n${historyBlock}\n\n以上是最近若干轮用户可见对话。当前消息如果明显是新的独立任务，请忽略旧历史并按新任务处理；如果它是上一轮任务的确认、补充或纠正，请结合历史继续处理。无法确定时向用户确认。`
+		: loadSystemPrompt(selectedProjects);
+	const canControlConversation = isImSession && !selectedProjects.includes(SCHEDULER_VIRTUAL_PROJECT);
 	const clearToolInstruction = canControlConversation
 		? "\n\n# 会话上下文控制\n你可以使用 clear_conversation_context 工具。仅当用户明确要求清空 / 忽略 / 重置之前的上下文（例如「新任务」「忽略上文」「重置上下文」，或等价表达）时，在处理当前请求前调用该工具一次。调用后，如果用户还带有具体任务，继续完成该任务；如果没有具体任务，只需简短确认已清空。"
 		: "";
@@ -469,16 +519,14 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 	});
 
 	// Inject the sender as the task context (for tools like schedule to auto-fill the push
-	// recipient), and allow the clear-conversation tool only for IM execute runs. Clear the
-	// context once the run ends — whether it succeeded or not.
-	setTaskContext(
-		isImSession || ctx.recipient
-			? {
-					recipient: ctx.recipient,
-					conversationSessionKey: canControlConversation ? ctx.sessionKey : undefined,
-				}
-			: null,
-	);
+	// recipient), the selected real data projects (for the path-tool subset check), and allow the
+	// clear-conversation tool only for IM execute runs. Clear the context once the run ends —
+	// whether it succeeded or not.
+	setTaskContext({
+		recipient: ctx.recipient,
+		conversationSessionKey: canControlConversation ? ctx.sessionKey : undefined,
+		projects: realSelectedProjects,
+	});
 	try {
 		markAgentStart();
 		// Inline vision (decoded bytes) + the saved-path note, so the model can both see the
@@ -510,7 +558,7 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 				.filter((c) => c.type === "text")
 				.map((c) => (c as { text: string }).text)
 				.join("");
-			({ text, images } = extractImages(raw));
+			({ text, images } = extractImages(raw, realSelectedProjects));
 		}
 	} else if (last && last.role === "toolResult" && toolTurnCapHit) {
 		// Hard-stopped at the tool-turn cap: the last message is a toolResult with no final reply, so return fallback copy
@@ -551,7 +599,7 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 		source: ctx.source,
 		provider: CONFIG.provider,
 		model: CONFIG.model,
-		project,
+		projects: selectedProjects,
 		startedAt,
 		endedAt,
 		userMessage,
@@ -561,7 +609,7 @@ export async function runTask(userMessage: string, logCtx?: RunLogContext): Prom
 		inboundImageCount: inboundImages.length,
 		messages: state.messages,
 		routingUsage,
-		routing: { candidates: routingCandidates, decision: project, prompt: routingPrompt },
+		routing: { candidates: routingCandidates, decision: legacyProject(selectedProjects), prompt: routingPrompt },
 		systemPrompt,
 		modelCache: snapshotModelCache(),
 	});

--- a/src/runner/decisions.test.ts
+++ b/src/runner/decisions.test.ts
@@ -1,10 +1,13 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
+	emptyRoute,
 	parseRoute,
 	shouldClearConversationForRoute,
 	shouldRecordConversationTurn,
 } from "./decisions.ts";
+
+const COOK_VOCAB = ["cook", "vocab"];
 
 test("parseRoute accepts reset-context sentinel with tolerant casing and surrounding tokens", () => {
 	for (const output of [
@@ -14,40 +17,147 @@ test("parseRoute accepts reset-context sentinel with tolerant casing and surroun
 		"RESET_CONTEXT。",
 		"RESET_CONTEXT（用户明确要求忽略上文）",
 	]) {
-		assert.deepEqual(parseRoute(output, ["cook", "vocab"]), {
-			project: null,
+		assert.deepEqual(parseRoute(output, COOK_VOCAB), {
+			projects: [],
+			attachmentProject: null,
 			resetContext: true,
 		});
 	}
 });
 
 test("parseRoute does not treat reset-context prefixes as a reset decision", () => {
-	assert.deepEqual(parseRoute("RESET_CONTEXTUAL", ["cook", "vocab"]), {
-		project: null,
+	assert.deepEqual(parseRoute("RESET_CONTEXTUAL", COOK_VOCAB), emptyRoute());
+});
+
+test("parseRoute parses a structured single-project JSON route", () => {
+	assert.deepEqual(parseRoute('{"projects":["cook"],"attachmentProject":null}', COOK_VOCAB), {
+		projects: ["cook"],
+		attachmentProject: null,
 		resetContext: false,
 	});
 });
 
-test("parseRoute still routes ordinary project names and unknown output", () => {
-	assert.deepEqual(parseRoute("cook", ["cook", "vocab"]), {
-		project: "cook",
+test("parseRoute parses a multi-project JSON route preserving order", () => {
+	assert.deepEqual(
+		parseRoute('{"projects":["cook","vocab"],"attachmentProject":"cook"}', COOK_VOCAB),
+		{ projects: ["cook", "vocab"], attachmentProject: "cook", resetContext: false },
+	);
+});
+
+test("parseRoute deduplicates repeated project names in order", () => {
+	assert.deepEqual(parseRoute('{"projects":["cook","vocab","cook"],"attachmentProject":null}', COOK_VOCAB), {
+		projects: ["cook", "vocab"],
+		attachmentProject: null,
 		resetContext: false,
 	});
-	assert.deepEqual(parseRoute("无法确定", ["cook", "vocab"]), {
-		project: null,
+});
+
+test("parseRoute strips code fences and leading prose before JSON", () => {
+	assert.deepEqual(
+		parseRoute('好的：```json\n{"projects":["cook"],"attachmentProject":null}\n```', COOK_VOCAB),
+		{ projects: ["cook"], attachmentProject: null, resetContext: false },
+	);
+});
+
+test("parseRoute rejects UNKNOWN and natural-language markers", () => {
+	for (const output of ["UNKNOWN", "无法确定", "不确定", "无法判断", "不明确"]) {
+		assert.deepEqual(parseRoute(output, COOK_VOCAB), emptyRoute());
+	}
+});
+
+test("parseRoute rejects an empty projects array", () => {
+	assert.deepEqual(parseRoute('{"projects":[],"attachmentProject":null}', COOK_VOCAB), emptyRoute());
+});
+
+test("parseRoute rejects non-object / non-array-projects JSON", () => {
+	assert.deepEqual(parseRoute('{"projects":"cook"}', COOK_VOCAB), emptyRoute());
+	assert.deepEqual(parseRoute('{"projects":[1]}', COOK_VOCAB), emptyRoute());
+	assert.deepEqual(parseRoute('"cook"', COOK_VOCAB), emptyRoute());
+});
+
+test("parseRoute rejects a project name not in the candidate list", () => {
+	assert.deepEqual(parseRoute('{"projects":["other"],"attachmentProject":null}', COOK_VOCAB), emptyRoute());
+});
+
+test("parseRoute rejects __scheduler__ mixed with data projects", () => {
+	assert.deepEqual(
+		parseRoute('{"projects":["cook","__scheduler__"],"attachmentProject":null}', [...COOK_VOCAB, "__scheduler__"]),
+		emptyRoute(),
+	);
+	assert.deepEqual(
+		parseRoute('{"projects":["__scheduler__","cook"],"attachmentProject":null}', [...COOK_VOCAB, "__scheduler__"]),
+		emptyRoute(),
+	);
+});
+
+test("parseRoute accepts __scheduler__ only as the sole entry", () => {
+	assert.deepEqual(
+		parseRoute('{"projects":["__scheduler__"],"attachmentProject":null}', [...COOK_VOCAB, "__scheduler__"]),
+		{ projects: ["__scheduler__"], attachmentProject: null, resetContext: false },
+	);
+});
+
+test("parseRoute rejects a scheduler attachmentProject", () => {
+	assert.deepEqual(
+		parseRoute('{"projects":["__scheduler__"],"attachmentProject":"__scheduler__"}', [...COOK_VOCAB, "__scheduler__"]),
+		emptyRoute(),
+	);
+});
+
+test("parseRoute rejects an attachmentProject outside projects", () => {
+	assert.deepEqual(
+		parseRoute('{"projects":["cook"],"attachmentProject":"vocab"}', COOK_VOCAB),
+		emptyRoute(),
+	);
+});
+
+test("parseRoute treats a string \"null\" attachmentProject as no attachment", () => {
+	assert.deepEqual(parseRoute('{"projects":["cook"],"attachmentProject":"null"}', COOK_VOCAB), {
+		projects: ["cook"],
+		attachmentProject: null,
 		resetContext: false,
 	});
+});
+
+test("parseRoute falls back to a single exact bare project name (non-JSON output)", () => {
+	assert.deepEqual(parseRoute("cook", COOK_VOCAB), {
+		projects: ["cook"],
+		attachmentProject: null,
+		resetContext: false,
+	});
+	assert.deepEqual(parseRoute("好的，是 cook", COOK_VOCAB), {
+		projects: ["cook"],
+		attachmentProject: null,
+		resetContext: false,
+	});
+});
+
+test("parseRoute does not misroute a project that is a substring of another", () => {
+	// "cook" is a substring of "cooking"; an exact match must not route "cooking" to "cook".
+	assert.deepEqual(parseRoute("cooking", ["cook", "cooking"]), {
+		projects: ["cooking"],
+		attachmentProject: null,
+		resetContext: false,
+	});
+	assert.deepEqual(parseRoute("cook", ["cook", "cooking"]), {
+		projects: ["cook"],
+		attachmentProject: null,
+		resetContext: false,
+	});
+});
+
+test("parseRoute returns unknown when more than one bare name appears in non-JSON output", () => {
+	assert.deepEqual(parseRoute("cook and vocab", COOK_VOCAB), emptyRoute());
+	assert.deepEqual(parseRoute("cook/vocab", COOK_VOCAB), emptyRoute());
 });
 
 test("parseRoute routes scheduler aliases only when the virtual project is a candidate", () => {
 	assert.deepEqual(parseRoute("定时", ["cook", "__scheduler__"]), {
-		project: "__scheduler__",
+		projects: ["__scheduler__"],
+		attachmentProject: null,
 		resetContext: false,
 	});
-	assert.deepEqual(parseRoute("定时", ["cook"]), {
-		project: null,
-		resetContext: false,
-	});
+	assert.deepEqual(parseRoute("定时", ["cook"]), emptyRoute());
 });
 
 test("shouldRecordConversationTurn suppresses only clear-only executions", () => {

--- a/src/runner/decisions.ts
+++ b/src/runner/decisions.ts
@@ -7,32 +7,103 @@ import { RESET_CONTEXT_DECISION, SCHEDULER_VIRTUAL_PROJECT } from "../prompts/sy
 
 const CLEAR_CONVERSATION_TOOL = "clear_conversation_context";
 const RESET_CONTEXT_PATTERN = new RegExp(`^${RESET_CONTEXT_DECISION}\\b`, "i");
+const UNKNOWN_PATTERN = /unknown|无法确定|不确定|无法判断|不明确/i;
+const SCHEDULER_ALIAS_PATTERN = /定时|提醒|日程/;
 
 export interface RouteDecision {
-	project: string | null;
+	/** Ordered, deduplicated selected subprojects; [] = unknown (no project). */
+	projects: string[];
+	/** For image-bearing messages, the single selected project where the original is saved; null otherwise. */
+	attachmentProject: string | null;
 	resetContext: boolean;
 }
 
+export function emptyRoute(): RouteDecision {
+	return { projects: [], attachmentProject: null, resetContext: false };
+}
+
+/** Strip surrounding markdown code fences and trim whitespace. */
+function stripCodeFences(s: string): string {
+	return s
+		.replace(/^```[a-zA-Z]*\s*\n?/, "")
+		.replace(/\n?```\s*$/, "")
+		.trim();
+}
+
+/** Slice a string from the first `{` so prose prepended before JSON still parses. */
+function sliceFromFirstBrace(s: string): string {
+	const idx = s.indexOf("{");
+	return idx === -1 ? s : s.slice(idx);
+}
+
+function validateRoute(value: unknown, candidates: readonly string[]): RouteDecision {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return emptyRoute();
+	const obj = value as Record<string, unknown>;
+	if (!Array.isArray(obj.projects)) return emptyRoute();
+
+	const projects: string[] = [];
+	for (const p of obj.projects) {
+		if (typeof p !== "string" || !candidates.includes(p)) return emptyRoute();
+		if (!projects.includes(p)) projects.push(p);
+	}
+	if (projects.length === 0) return emptyRoute();
+
+	// The scheduler virtual project is exclusive: it must be the sole entry, never mixed with data projects.
+	if (projects.includes(SCHEDULER_VIRTUAL_PROJECT) && projects.length > 1) return emptyRoute();
+
+	const rawAtt = obj.attachmentProject;
+	let attachmentProject: string | null = null;
+	if (rawAtt !== undefined && rawAtt !== null && rawAtt !== "null") {
+		if (typeof rawAtt !== "string") return emptyRoute();
+		if (rawAtt === SCHEDULER_VIRTUAL_PROJECT) return emptyRoute();
+		if (!projects.includes(rawAtt)) return emptyRoute();
+		attachmentProject = rawAtt;
+	}
+
+	return { projects, attachmentProject, resetContext: false };
+}
+
+/** Exact (whole-token) match of a candidate name in free text, tolerant of punctuation. */
+function exactNameMatches(text: string, candidates: readonly string[]): string[] {
+	const tokens = text.split(/[^A-Za-z0-9_-]+/).filter(Boolean);
+	return candidates.filter((c) => tokens.includes(c));
+}
+
 /**
- * Parse the routing output into a project name; returns null if undetermined.
- * The candidate list includes the virtual `__scheduler__` project. Aliases are
- * matched only AFTER real-project matches, so a message targeting a data project
- * is never stolen by the scheduler; "task" alone is deliberately not an alias.
+ * Parse the routing output (structured JSON) into an ordered set of selected subprojects.
+ * The candidate list includes the virtual `__scheduler__` project. Aliases are matched only
+ * AFTER real-project matches, so a message targeting a data project is never stolen by the
+ * scheduler; "task" alone is deliberately not an alias.
  */
-export function parseRoute(output: string, projects: string[]): RouteDecision {
-	const t = output.replace(/^[-*\s]+/, "").replace(/[\/\s]+$/, "").trim();
-	if (!t) return { project: null, resetContext: false };
-	if (RESET_CONTEXT_PATTERN.test(t)) {
-		return { project: null, resetContext: true };
+export function parseRoute(output: string, candidates: string[]): RouteDecision {
+	const t = stripCodeFences(output.replace(/^[-*\s]+/, "").trim());
+	if (!t) return emptyRoute();
+	if (RESET_CONTEXT_PATTERN.test(t)) return { ...emptyRoute(), resetContext: true };
+	if (UNKNOWN_PATTERN.test(t)) return emptyRoute();
+
+	const parsed = (() => {
+		try {
+			return JSON.parse(sliceFromFirstBrace(t)) as unknown;
+		} catch {
+			return undefined;
+		}
+	})();
+	if (parsed !== undefined) return validateRoute(parsed, candidates);
+
+	// Tolerant fallback for a model that ignores the JSON instruction and replies with a bare
+	// project name: route only when exactly one candidate name appears (whole-token match).
+	const matches = exactNameMatches(t, candidates);
+	if (matches.length === 1) {
+		return { projects: [matches[0]], attachmentProject: null, resetContext: false };
 	}
-	if (/unknown|无法确定|不确定|无法判断|不明确|多个|both/i.test(t)) {
-		return { project: null, resetContext: false };
+	if (
+		matches.length === 0 &&
+		candidates.includes(SCHEDULER_VIRTUAL_PROJECT) &&
+		(t === "scheduler" || SCHEDULER_ALIAS_PATTERN.test(t))
+	) {
+		return { projects: [SCHEDULER_VIRTUAL_PROJECT], attachmentProject: null, resetContext: false };
 	}
-	if (projects.includes(t)) return { project: t, resetContext: false };
-	for (const p of projects) if (t.includes(p)) return { project: p, resetContext: false };
-	if (projects.includes(SCHEDULER_VIRTUAL_PROJECT) && (t === "scheduler" || /定时|提醒|日程/.test(t)))
-		return { project: SCHEDULER_VIRTUAL_PROJECT, resetContext: false };
-	return { project: null, resetContext: false };
+	return emptyRoute();
 }
 
 /**

--- a/src/safety/git.test.ts
+++ b/src/safety/git.test.ts
@@ -1,0 +1,59 @@
+import { before, test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+let git: typeof import("./git.ts");
+
+let root = "";
+
+function log(project: string): string {
+	try {
+		return execFileSync("git", ["log", "--oneline"], { cwd: path.join(root, project) }).toString().trim();
+	} catch {
+		return "";
+	}
+}
+
+before(async () => {
+	root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "botler-git-")));
+	for (const name of ["cook", "vocab"]) {
+		const dir = path.join(root, name);
+		fs.mkdirSync(dir);
+		execFileSync("git", ["init", "-q"], { cwd: dir });
+		execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: dir });
+		execFileSync("git", ["config", "user.name", "Test"], { cwd: dir });
+	}
+	process.env.DATA_ROOT = root;
+	process.env.GIT_PUSH = "0";
+	git = await import("./git.ts");
+});
+
+test("commitIfChanged scoped to a selected repo only commits that repo", () => {
+	for (const name of ["cook", "vocab"]) {
+		fs.writeFileSync(path.join(root, name, "data.json"), '{"v":1}');
+	}
+
+	git.commitIfChanged("test: scoped commit", ["cook"]);
+
+	assert.match(log("cook"), /test: scoped commit/);
+	assert.equal(log("vocab"), "");
+});
+
+test("commitIfChanged with no projects commits every changed repo", () => {
+	fs.writeFileSync(path.join(root, "vocab", "second.json"), '{"v":2}');
+
+	git.commitIfChanged("test: all commit");
+
+	assert.match(log("vocab"), /test: all commit/);
+});
+
+test("commitIfChanged with an empty set commits nothing", () => {
+	fs.writeFileSync(path.join(root, "cook", "third.json"), '{"v":3}');
+
+	const beforeCook = log("cook");
+	git.commitIfChanged("test: empty", []);
+	assert.equal(log("cook"), beforeCook);
+});

--- a/src/safety/git.ts
+++ b/src/safety/git.ts
@@ -8,7 +8,7 @@ import { CONFIG } from "../config.ts";
  * and has non-empty `git status --porcelain`, gets add + commit. The glue layer does the commit; the agent never touches bash.
  * When GIT_PUSH=1, additionally push (failure is only a warning, not a blocker).
  */
-export function commitIfChanged(msg: string): void {
+export function commitIfChanged(msg: string, projects?: readonly string[]): void {
 	if (!CONFIG.dataRoot) return;
 	const root = resolve(CONFIG.dataRoot);
 	if (!existsSync(root)) return;
@@ -22,6 +22,7 @@ export function commitIfChanged(msg: string): void {
 
 	for (const d of entries) {
 		if (!d.isDirectory() || d.name.startsWith(".")) continue;
+		if (projects && !projects.includes(d.name)) continue;
 		const dir = join(root, d.name);
 		if (!existsSync(join(dir, ".git"))) continue;
 		try {

--- a/src/safety/validate.test.ts
+++ b/src/safety/validate.test.ts
@@ -1,0 +1,44 @@
+import { before, test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+let validate: typeof import("./validate.ts");
+
+before(async () => {
+	const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "botler-validate-")));
+	fs.mkdirSync(path.join(root, "cook", "data"), { recursive: true });
+	fs.mkdirSync(path.join(root, "vocab", "data"), { recursive: true });
+	fs.writeFileSync(path.join(root, "cook", "data", "a.json"), '{"ok":true}');
+	fs.writeFileSync(path.join(root, "vocab", "data", "broken.json"), '{"oops":');
+	process.env.DATA_ROOT = root;
+	validate = await import("./validate.ts");
+});
+
+test("validateState with no projects scans everything and reports the broken project", () => {
+	const r = validate.validateState();
+	assert.equal(r.ok, false);
+	assert.match(r.fix ?? "", /broken\.json/);
+});
+
+test("validateState scoped to a valid selected project passes even when a sibling is broken", () => {
+	const r = validate.validateState(["cook"]);
+	assert.equal(r.ok, true);
+});
+
+test("validateState scoped to the broken project fails", () => {
+	const r = validate.validateState(["vocab"]);
+	assert.equal(r.ok, false);
+	assert.match(r.fix ?? "", /broken\.json/);
+});
+
+test("validateState with an empty set validates nothing", () => {
+	assert.equal(validate.validateState([]).ok, true);
+});
+
+test("validateState ignores an unknown project name and does not traverse outside DATA_ROOT", () => {
+	// ".." and a nonexistent name must be dropped, not resolved into the filesystem.
+	assert.equal(validate.validateState([".."]).ok, true);
+	assert.equal(validate.validateState(["nonexistent"]).ok, true);
+});

--- a/src/safety/validate.ts
+++ b/src/safety/validate.ts
@@ -1,6 +1,7 @@
 import { readFileSync, existsSync, readdirSync, type Dirent } from "node:fs";
 import { resolve, join, extname, relative } from "node:path";
 import { CONFIG } from "../config.ts";
+import { listProjectDirs } from "../prompts/system-prompt.ts";
 
 export interface ValidationResult {
 	ok: boolean;
@@ -30,14 +31,15 @@ function* walkJson(dir: string): Generator<string> {
 	}
 }
 
-/** Collect all JSON data files within the allowlist, returning paths relative to DATA_ROOT. */
-function collectJsonFiles(): string[] {
+/** Collect JSON data files within the selected project dirs, returning paths relative to DATA_ROOT. */
+function collectJsonFiles(projects?: readonly string[]): string[] {
 	if (!CONFIG.dataRoot) return [];
 	const root = resolve(CONFIG.dataRoot);
 	if (!existsSync(root)) return [];
 	const rel: string[] = [];
 	for (const d of readdirSync(root, { withFileTypes: true })) {
 		if (!d.isDirectory() || d.name.startsWith(".")) continue;
+		if (projects && !projects.includes(d.name)) continue;
 		for (const f of walkJson(join(root, d.name))) {
 			rel.push(relative(root, f));
 		}
@@ -49,9 +51,14 @@ function collectJsonFiles(): string[] {
  * Post-write validation: all data JSON must be valid JSON.
  * The write tool guarantees valid serialization; edit is text replacement and may break JSON syntax — this is the safety net.
  * Business-semantic correctness (field values, aggregation consistency, etc.) is guaranteed by each subproject's AGENTS.md conventions and its own scripts; the framework does not hardcode it.
+ *
+ * `projects` scopes validation to the selected set (an unrelated dirty/broken sibling must not
+ * block a multi-project task); `undefined` validates every project. Names are verified against
+ * `listProjectDirs()` so a ".." or unknown name can never escape the DATA_ROOT boundary.
  */
-export function validateState(): ValidationResult {
-	for (const rel of collectJsonFiles()) {
+export function validateState(projects?: readonly string[]): ValidationResult {
+	const scoped = projects ? listProjectDirs().filter((n) => projects.includes(n)) : undefined;
+	for (const rel of collectJsonFiles(scoped)) {
 		let raw: string;
 		try {
 			raw = readFileSync(resolve(CONFIG.dataRoot, rel), "utf8");

--- a/src/scheduler/history.test.ts
+++ b/src/scheduler/history.test.ts
@@ -175,6 +175,37 @@ test("orphanHistoryIndex caps the index at 200 ids, keeping the newest", () => {
 	assert.ok(!index.some((i) => i.scheduleId === "id-0"));
 });
 
+test("scheduleOverviewFromLogs joins a multi-project lastRun into a readable string", () => {
+	const entries = [makeEntry({ id: "foo" })];
+	const logs = [
+		makeLog({
+			id: "run",
+			taskId: "schedule:foo:1720000000000",
+			project: null,
+			projects: ["cook", "vocab"],
+		}),
+	];
+
+	const overview = scheduleOverviewFromLogs(entries, logs);
+
+	assert.equal(overview[0]?.lastRun?.project, "cook, vocab");
+});
+
+test("orphanHistoryIndex joins a multi-project lastProject into a readable string", () => {
+	const logs = [
+		makeLog({
+			id: "run",
+			taskId: "schedule:foo:1720000000000",
+			project: null,
+			projects: ["cook", "vocab"],
+		}),
+	];
+
+	const [foo] = orphanHistoryIndex([], logs);
+
+	assert.equal(foo.lastProject, "cook, vocab");
+});
+
 test("aggregateRunStats handles an empty log stream", () => {
 	const stats = aggregateRunStats("empty", (visit) => {
 		// No logs visited.

--- a/src/scheduler/history.ts
+++ b/src/scheduler/history.ts
@@ -124,7 +124,7 @@ function toLastRun(l: TaskLog | undefined): ScheduleLastRun | null {
 				startedAt: l.startedAt,
 				status: l.status,
 				durationMs: l.durationMs,
-				project: l.project,
+				project: l.project ?? (l.projects?.join(", ") || null),
 				tokenTotal: l.usage.total,
 			}
 		: null;
@@ -236,7 +236,7 @@ function finishHistory(
 			firstRunAt: a.first,
 			lastRunAt: a.last,
 			lastStatus: a.log.status,
-			lastProject: a.log.project,
+			lastProject: a.log.project ?? (a.log.projects?.join(", ") || null),
 			lastMessage: a.log.userMessage.slice(0, HISTORY_MESSAGE_CHARS),
 		});
 	}

--- a/src/tools/edit.ts
+++ b/src/tools/edit.ts
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { Type } from "@earendil-works/pi-ai";
 import { safePath } from "./paths.ts";
+import { getTaskProjects } from "./task-context.ts";
 
 const schema = Type.Object({
 	path: Type.String({ description: "File path relative to DATA_ROOT" }),
@@ -22,7 +23,7 @@ export const editTool: AgentTool<typeof schema> = {
 		"Replace oldText with newText in a file. oldText must match the file's existing content character-for-character (including spaces and newlines), otherwise it fails. all=true replaces all matches, otherwise only the first. Used for local fixes inside JSON files.",
 	parameters: schema,
 	async execute(_toolCallId, { path, oldText, newText, all }) {
-		const abs = safePath(path);
+		const abs = safePath(path, { projects: getTaskProjects() });
 		const current = readFileSync(abs, "utf8");
 		if (!current.includes(oldText)) {
 			throw new Error(`oldText not found in the original file (first 60 chars): ${oldText.slice(0, 60)}`);

--- a/src/tools/paths.test.ts
+++ b/src/tools/paths.test.ts
@@ -1,0 +1,59 @@
+import { before, test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+let paths: typeof import("./paths.ts");
+
+before(async () => {
+	const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "botler-paths-")));
+	fs.mkdirSync(path.join(root, "cook"));
+	fs.mkdirSync(path.join(root, "vocab"));
+	fs.writeFileSync(path.join(root, "cook", "a.json"), "{}");
+	fs.writeFileSync(path.join(root, "vocab", "b.json"), "{}");
+	process.env.DATA_ROOT = root;
+	paths = await import("./paths.ts");
+});
+
+test("safePath with no projects stays unrestricted across all projects", () => {
+	assert.ok(paths.safePath("cook/a.json").endsWith(path.join("cook", "a.json")));
+	assert.ok(paths.safePath("vocab/b.json").endsWith(path.join("vocab", "b.json")));
+});
+
+test("safePath authorizes a path inside the selected project", () => {
+	assert.ok(paths.safePath("cook/a.json", { projects: ["cook"] }).endsWith(path.join("cook", "a.json")));
+});
+
+test("safePath rejects a path inside an unselected project", () => {
+	assert.throws(() => paths.safePath("vocab/b.json", { projects: ["cook"] }), /not selected/);
+});
+
+test("safePath rejects a path out of bounds regardless of the selected set", () => {
+	assert.throws(() => paths.safePath("../outside.json", { projects: ["cook"] }), /out of bounds/);
+	assert.throws(() => paths.safePath("cook/../../../etc/passwd", { projects: ["cook"] }), /out of bounds/);
+});
+
+test("safePath rejects a sibling prefix that is not a real project", () => {
+	// "cook2" is not an allowlisted project; it must never match the "cook" root.
+	assert.throws(() => paths.safePath("cook2/x.json", { projects: ["cook"] }), /out of bounds/);
+});
+
+test("safePath rejects a traversal from a selected project into an unselected one", () => {
+	assert.throws(() => paths.safePath("cook/../vocab/b.json", { projects: ["cook"] }), /not selected/);
+});
+
+test("safePath authorizes a multi-project set", () => {
+	assert.ok(paths.safePath("cook/a.json", { projects: ["cook", "vocab"] }).endsWith(path.join("cook", "a.json")));
+	assert.ok(paths.safePath("vocab/b.json", { projects: ["cook", "vocab"] }).endsWith(path.join("vocab", "b.json")));
+});
+
+test("safePath rejects a symlink escaping into an unselected project", () => {
+	fs.symlinkSync(path.join(process.env.DATA_ROOT!, "vocab"), path.join(process.env.DATA_ROOT!, "cook", "link"));
+	assert.throws(() => paths.safePath("cook/link/b.json", { projects: ["cook"] }), /not selected/);
+});
+
+test("projectOf returns the owning project name", () => {
+	const abs = paths.safePath("cook/a.json");
+	assert.equal(paths.projectOf(abs), "cook");
+});

--- a/src/tools/paths.ts
+++ b/src/tools/paths.ts
@@ -33,6 +33,18 @@ const ROOTS = ALLOWED.map((d) => (existsSync(d) ? resolve(d) : d));
 export interface SafePathOptions {
 	/** Whether to realpath the deepest existing ancestor, to prevent symlink escapes outside the allowlist. Default on. */
 	followSymlinks?: boolean;
+	/** Optional task-local subset: when set, the resolved path must fall inside one of these projects (on top of the global allowlist). */
+	projects?: readonly string[];
+}
+
+/** Enforce the task-local subset (additive on top of the global allowlist); no-op for framework calls without a subset. */
+function assertSelectedProject(abs: string, projects: readonly string[] | undefined): void {
+	if (!projects) return;
+	const selected = new Set(projects);
+	const matchedRoot = ROOTS.find((root) => abs === root || abs.startsWith(root + sep));
+	if (!matchedRoot || !selected.has(basename(matchedRoot))) {
+		throw new Error(`Path not selected for this task: ${abs}`);
+	}
 }
 
 /**
@@ -46,6 +58,7 @@ export function safePath(p: string, opts: SafePathOptions = {}): string {
 	if (!ok) {
 		throw new Error(`Path out of bounds (not within the allowed directory): ${p}`);
 	}
+	assertSelectedProject(abs, opts.projects);
 
 	if (opts.followSymlinks ?? true) {
 		// realpath the "deepest existing ancestor", then concatenate the remaining path back, and verify once more,
@@ -60,6 +73,7 @@ export function safePath(p: string, opts: SafePathOptions = {}): string {
 		if (!ROOTS.some((root) => real === root || real.startsWith(root + sep))) {
 			throw new Error(`Path out of bounds (symlink escape): ${p}`);
 		}
+		assertSelectedProject(real, opts.projects);
 		return real;
 	}
 

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { Type } from "@earendil-works/pi-ai";
 import { safePath } from "./paths.ts";
+import { getTaskProjects } from "./task-context.ts";
 
 const schema = Type.Object({
 	path: Type.String({
@@ -17,7 +18,7 @@ export const readTool: AgentTool<typeof schema> = {
 		"Read the content of a file inside the data directory. The path is relative to DATA_ROOT and limited to data subprojects under DATA_ROOT. Returns the raw file content (JSON files as JSON text) so you can understand the current data before deciding how to modify it.",
 	parameters: schema,
 	async execute(_toolCallId, { path }) {
-		const abs = safePath(path);
+		const abs = safePath(path, { projects: getTaskProjects() });
 		const content = readFileSync(abs, "utf8");
 		return {
 			content: [{ type: "text", text: content }],

--- a/src/tools/run.ts
+++ b/src/tools/run.ts
@@ -4,6 +4,7 @@ import { resolve } from "node:path";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { Type } from "@earendil-works/pi-ai";
 import { safePath, projectOf } from "./paths.ts";
+import { getTaskProjects } from "./task-context.ts";
 import { CONFIG } from "../config.ts";
 
 /** Fixed interpreter per extension; the script must already exist inside an allowlisted project, eliminating arbitrary execution like `python3 -c`. */
@@ -35,7 +36,7 @@ export const runTool: AgentTool<typeof schema> = {
 		"Run an existing script inside a data subproject (only python3 .py or node .js/.mjs), used to run build/refresh scripts defined by the project's conventions (e.g. build.py). No shell is used; args are passed directly; the working directory is locked to the script's subproject root with a 60-second timeout. Only run it when the project's conventions (AGENTS.md) require it; skip if the project has no such script.",
 	parameters: schema,
 	async execute(_toolCallId, { script, args = [] }) {
-		const abs = safePath(script);
+		const abs = safePath(script, { projects: getTaskProjects() });
 		if (!existsSync(abs) || !statSync(abs).isFile()) {
 			throw new Error(`Script does not exist or is not a file: ${script}`);
 		}

--- a/src/tools/task-context.ts
+++ b/src/tools/task-context.ts
@@ -9,11 +9,16 @@
 
 import type { Recipient } from "../push/types.ts";
 
-let current: { recipient?: Recipient; conversationSessionKey?: string } | null = null;
+let current: {
+	recipient?: Recipient;
+	conversationSessionKey?: string;
+	projects?: readonly string[];
+} | null = null;
 
 export function setTaskContext(c: {
 	recipient?: Recipient;
 	conversationSessionKey?: string;
+	projects?: readonly string[];
 } | null): void {
 	current = c;
 }
@@ -21,6 +26,12 @@ export function setTaskContext(c: {
 export function getTaskContext(): {
 	recipient?: Recipient;
 	conversationSessionKey?: string;
+	projects?: readonly string[];
 } | null {
 	return current;
+}
+
+/** Task-local selected projects for path-tool enforcement; undefined when no subset is active. */
+export function getTaskProjects(): readonly string[] | undefined {
+	return current?.projects;
 }

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -3,6 +3,7 @@ import { dirname } from "node:path";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { Type } from "@earendil-works/pi-ai";
 import { safePath } from "./paths.ts";
+import { getTaskProjects } from "./task-context.ts";
 
 const schema = Type.Object({
 	path: Type.String({
@@ -47,7 +48,7 @@ export const writeTool: AgentTool<typeof schema> = {
 				}. Pass the data structure itself — this tool handles serialization.`,
 			);
 		}
-		const abs = safePath(path);
+		const abs = safePath(path, { projects: getTaskProjects() });
 		mkdirSync(dirname(abs), { recursive: true });
 		const text = JSON.stringify(value, null, 2);
 		writeFileSync(abs, text, "utf8");

--- a/src/webui/index.html
+++ b/src/webui/index.html
@@ -408,7 +408,7 @@ async function loadList(){
     return `<tr class="row" data-id="${esc(l.id)}">
       <td>${fmtTime(l.startedAt)}</td>
       <td>${esc(l.source)}</td>
-      <td>${esc(l.project||"—")}</td>
+      <td>${esc(l.projects?.length ? l.projects.join(", ") : (l.project||"—"))}</td>
       <td>${statusBadge(l.status)}</td>
       <td>${fmtDur(l.durationMs)}</td>
       <td>${l.usage.total}</td>
@@ -515,7 +515,7 @@ async function showDetail(id, opts){
         <div class="k">End</div><div>${fmtTime(l.endedAt)}</div>
         <div class="k">Duration</div><div>${fmtDur(l.durationMs)}</div>
         <div class="k">provider/model</div><div>${esc(l.provider)} / ${esc(l.model)}</div>
-        <div class="k">Project</div><div>${esc(l.project||"—")}</div>
+        <div class="k">Project</div><div>${esc(l.projects?.length ? l.projects.join(", ") : (l.project||"—"))}</div>
         <div class="k">Channel</div><div>${esc(l.source)}</div>
         <div class="k">mutated</div><div>${l.mutated?"Yes":"No"}</div>
         <div class="k">Images</div><div>${l.images?.length||0}</div>
@@ -1039,7 +1039,7 @@ async function loadSchedHistory(){
         <td>${fmtTime(l.startedAt)}</td>
         <td>${statusBadge(l.status)}</td>
         <td>${l.phase==="self-heal"?'<span class="badge b-auto-fixed">self-heal</span>':""}</td>
-        <td>${esc(l.project||"—")}</td>
+        <td>${esc(l.projects?.length ? l.projects.join(", ") : (l.project||"—"))}</td>
         <td>${fmtDur(l.durationMs)}</td>
         <td>${l.usage.total}</td>
         <td>${esc((l.replyText||"").slice(0,80))}</td>


### PR DESCRIPTION
## Summary

Implements `docs/ds-multi-project.md`: let a single user message operate on **multiple** data subprojects, while keeping execution **serial** (one `Agent`, one tool call at a time). No parallel agents or worker pools.

The routed set is enforced at three levels:

1. **Prompt** — the execution prompt concatenates every selected subproject's convention doc and is told to only touch the selected set.
2. **Tools** — a task-local `projects` subset is enforced in `safePath` (additive on top of the global `DATA_ROOT` allowlist, checked before and after `realpath`).
3. **Safety** — `validateState` / `commitIfChanged` are scoped to the selected set, so an unrelated dirty/broken sibling can't block or be committed by a multi-project task.

## Key changes

- `parseRoute` returns a structured `RouteDecision` (`projects[]`, `attachmentProject`, `resetContext`): JSON-first parsing with fence/prose tolerance, `__scheduler__` exclusivity, `attachmentProject` membership validation, and an exact-token fallback for models that reply with a bare project name.
- `loadSystemPrompt` / `buildRoutePrompt` now accept a project array; the built-in prompt allows the selected set only.
- `read`/`write`/`edit`/`run` pass `getTaskProjects()` into `safePath`; `schedule` and `clear_conversation_context` are unchanged (no data path).
- Inbound images persist only to a single explicit `attachmentProject` (defaulted when exactly one real project is selected; multi-project without one is rejected).
- Logging / conversation / scheduler-history / WebUI carry a plural `projects` field (with `legacyProject` fallback), so multi-project tasks aggregate, filter, and render under every selected project. This also fixes the read-only multi-project task being mislabeled `unknown-project`.

## Tests

Added three new test files (wired into `npm test`): `src/tools/paths.test.ts`, `src/safety/validate.test.ts`, `src/safety/git.test.ts`, plus expanded cases in `decisions.test.ts`, `logging/store.test.ts`, `conversation/store.test.ts`, `scheduler/history.test.ts`. Full suite: 197 passing; `npm run typecheck` clean.

## Manual Verification Required

- Real end-to-end routing: a multi-subproject message must actually select multiple projects via the routing LLM and produce a reply that references both.
- Path-tool subset behavior in a live Agent run (the module-level task context is cleared after each run — confirm a second message to an unselected project is properly blocked/allowed per its own route).
- WeChat inbound-image flow: single-project default attachment, and the multi-project "add a text description" fallback.
- WebUI task table / detail / schedule runs project column rendering for a multi-project log (shows `cook, vocab`).
- Externalized `~/.botler-agent/system-prompt.md` still works (multi-project content is delivered via `__PROJECT_CONTEXT__`).

## Regression Checklist

- Single-project setups and single-project messages behave identically (backward compatible).
- Schedule management (`__scheduler__`) routing, the `schedule` tool, and `clear_conversation_context` still work; a scheduler route cannot access any data subproject.
- Greeting / reset-context / unknown-project short-circuits still return the correct deterministic replies.
- Self-heal on validation failure still scopes to the correct project set (`projectsHint`).
- `run` tool (in-project script execution) and `safePath` symlink-escape protection are unchanged for unrestricted framework calls.